### PR TITLE
fix: Follow 엔티티의 프로퍼티에 붙은 어노테이션 수정

### DIFF
--- a/src/main/kotlin/com/dooingle/domain/follow/model/Follow.kt
+++ b/src/main/kotlin/com/dooingle/domain/follow/model/Follow.kt
@@ -7,11 +7,11 @@ import jakarta.persistence.*
 @Table(name = "follow")
 class Follow(
     @ManyToOne
-    @Column
+    @JoinColumn
     val toUser: User,
 
     @ManyToOne
-    @Column
+    @JoinColumn
     val fromUser: User,
 ) {
 

--- a/src/main/kotlin/com/dooingle/domain/follow/model/Follow.kt
+++ b/src/main/kotlin/com/dooingle/domain/follow/model/Follow.kt
@@ -7,11 +7,11 @@ import jakarta.persistence.*
 @Table(name = "follow")
 class Follow(
     @ManyToOne
-    @JoinColumn
+    @JoinColumn(name = "to_user_id")
     val toUser: User,
 
     @ManyToOne
-    @JoinColumn
+    @JoinColumn(name = "from_user_id")
     val fromUser: User,
 ) {
 


### PR DESCRIPTION
## 연관 이슈
- closes #8 

## 해당 작업을 한 동기/이유는 무엇인가요?
- Follow 엔티티의 @ Column 어노테이션 때문에 서버 실행이 안 됨

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] Follow 엔티티 val toUser, val fromUser에 붙어있는 @ Column 어노테이션을 @ JoinColumn으로 수정
    - 연관관계가 있는 객체 프로퍼티에 대해서는 @ Column이 아니라 @ JoinColumn을 써야한다.
