### PR TITLE
add: integration workflow 추가

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,32 @@
+name: integration
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - add/**
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+
+      - name: Setup Java JDK 17 Adopt
+        uses: actions/setup-java@v4.0.0
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: gradlew build # build task는 test task를 포함함
+        run: ./gradlew build

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - dev
-      - add/**
 
 permissions:
   contents: read


### PR DESCRIPTION
## 연관 이슈
- closes #16 

## 해당 작업을 한 동기/이유는 무엇인가요?
- main, dev 브랜치에 push가 발생한 경우 빌드 작업을 실행하여 컴파일 에러 발생 여부, 테스트 통과 여부를 확인하고자 합니다.
  - dev 브랜치에 pull request가 발생한 경우 빌드 작업을 진행하는 편이 더 자연스럽다고 생각하지만,
  - 현재 개발 초기 단계이므로 서비스 운영 중이 아니고,
  - Actions 사용 시간에 따른 과금 우려가 있으므로,
  - 당분간은 push 이후 코드를 사후 확인하는 형태로 관리하겠습니다.

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] integration.yml 추가
    - GitHub Action를 이용하여 main, dev 브랜치에 push가 발생한 경우, Ubuntu 환경에서 해당 브랜치로 체크아웃 후 JDK 설치, Gradle의 build 태스크를 실행하는 workflow 
