### PR TITLE
feat:캐치 등록,삭제(소프트)기능 구현

### DIFF
--- a/src/main/kotlin/com/dooingle/domain/catch/controller/CatchController.kt
+++ b/src/main/kotlin/com/dooingle/domain/catch/controller/CatchController.kt
@@ -1,0 +1,43 @@
+package com.dooingle.domain.catch.controller
+
+import com.dooingle.domain.catch.dto.AddCatchRequest
+import com.dooingle.domain.catch.dto.CatchResponse
+import com.dooingle.domain.catch.dto.DeleteCatchRequest
+import com.dooingle.domain.catch.service.CatchService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+
+@Controller
+@RequestMapping("/api/dooingles/{dooingleId}/catches")
+class CatchController(
+    private val catchService: CatchService
+) {
+    // 캐치 생성
+    @PostMapping
+    fun addCatch(
+        @PathVariable dooingleId: Long,
+        @RequestBody addCatchRequest: AddCatchRequest
+    ): ResponseEntity<CatchResponse> {
+        val response: CatchResponse = catchService.addCatch(dooingleId, addCatchRequest)
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(response)
+    }
+    
+    // 캐치 삭제
+    @DeleteMapping("/{catchId}")
+    fun deleteCatch(
+        @PathVariable dooingleId: Long,
+        @PathVariable catchId: Long,
+        @RequestBody deleteCatchRequest: DeleteCatchRequest
+    ): ResponseEntity<Unit> {
+        catchService.deleteCatch(dooingleId, catchId, deleteCatchRequest)
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+    }
+}

--- a/src/main/kotlin/com/dooingle/domain/catch/dto/AddCatchRequest.kt
+++ b/src/main/kotlin/com/dooingle/domain/catch/dto/AddCatchRequest.kt
@@ -5,7 +5,6 @@ import com.dooingle.domain.dooingle.model.Dooingle
 
 data class AddCatchRequest(
     val ownerId: Long, // TODO : 추후 삭제 예정
-    val dooingleId: Long,
     val content: String
 ){
     fun to(dooingle: Dooingle): Catch {

--- a/src/main/kotlin/com/dooingle/domain/catch/dto/AddCatchRequest.kt
+++ b/src/main/kotlin/com/dooingle/domain/catch/dto/AddCatchRequest.kt
@@ -1,0 +1,17 @@
+package com.dooingle.domain.catch.dto
+
+import com.dooingle.domain.catch.model.Catch
+import com.dooingle.domain.dooingle.model.Dooingle
+
+data class AddCatchRequest(
+    val ownerId: Long, // TODO : 추후 삭제 예정
+    val dooingleId: Long,
+    val content: String
+){
+    fun to(dooingle: Dooingle): Catch {
+        return Catch(
+            dooingle = dooingle,
+            content = content
+        )
+    }
+}

--- a/src/main/kotlin/com/dooingle/domain/catch/dto/CatchResponse.kt
+++ b/src/main/kotlin/com/dooingle/domain/catch/dto/CatchResponse.kt
@@ -1,0 +1,22 @@
+package com.dooingle.domain.catch.dto
+
+import com.dooingle.domain.catch.model.Catch
+import java.time.ZonedDateTime
+
+data class CatchResponse(
+    val dooingleId: Long,
+    val catchId: Long,
+    val content: String,
+    val createdAt: ZonedDateTime
+){
+    companion object {
+        fun from(catch: Catch): CatchResponse {
+            return CatchResponse(
+                dooingleId = catch.dooingle.id!!,
+                catchId = catch.id!!,
+                content = catch.content,
+                createdAt = catch.createdAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/dooingle/domain/catch/dto/DeleteCatchRequest.kt
+++ b/src/main/kotlin/com/dooingle/domain/catch/dto/DeleteCatchRequest.kt
@@ -1,0 +1,6 @@
+package com.dooingle.domain.catch.dto
+
+// TODO : 추후 로그인 기능이 구현되면 삭제할 DTO
+data class DeleteCatchRequest(
+    val ownerId: Long
+)

--- a/src/main/kotlin/com/dooingle/domain/catch/model/Catch.kt
+++ b/src/main/kotlin/com/dooingle/domain/catch/model/Catch.kt
@@ -9,7 +9,7 @@ import java.time.ZonedDateTime
 @Table(name = "catch")
 class Catch(
     @Column
-    val content: String,
+    var content: String,
 
     @ManyToOne(fetch = FetchType.LAZY)
     val dooingle: Dooingle,
@@ -20,4 +20,8 @@ class Catch(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null
+
+    fun updateForDelete() {
+        this.deletedAt = ZonedDateTime.now()
+    }
 }

--- a/src/main/kotlin/com/dooingle/domain/catch/repository/CatchRepository.kt
+++ b/src/main/kotlin/com/dooingle/domain/catch/repository/CatchRepository.kt
@@ -1,0 +1,9 @@
+package com.dooingle.domain.catch.repository
+
+import com.dooingle.domain.catch.model.Catch
+import com.dooingle.domain.dooingle.model.Dooingle
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CatchRepository : JpaRepository<Catch,Long> {
+    fun existsByDooingle(dooingle: Dooingle): Boolean
+}

--- a/src/main/kotlin/com/dooingle/domain/catch/service/CatchService.kt
+++ b/src/main/kotlin/com/dooingle/domain/catch/service/CatchService.kt
@@ -15,7 +15,6 @@ class CatchService (
     private val catchRepository: CatchRepository
 ){
     // 캐치 생성
-    @Transactional
     fun addCatch(dooingleId: Long, addCatchRequest: AddCatchRequest): CatchResponse {
         val dooingle = dooingleRepository.findByIdOrNull(dooingleId) ?: throw Exception("") // TODO
 
@@ -23,7 +22,7 @@ class CatchService (
         if (dooingle.owner.id != addCatchRequest.ownerId) throw Exception("") // TODO
 
         // 해당 dooingle 의 주인은 하나의 catch 만 작성 가능하다
-        else if (catchRepository.existsByDooingle(dooingle)) throw Exception("") // TODO
+        if (catchRepository.existsByDooingle(dooingle)) throw Exception("") // TODO
 
         val catch = addCatchRequest.to(dooingle)
         catchRepository.save(catch)

--- a/src/main/kotlin/com/dooingle/domain/catch/service/CatchService.kt
+++ b/src/main/kotlin/com/dooingle/domain/catch/service/CatchService.kt
@@ -1,0 +1,46 @@
+package com.dooingle.domain.catch.service
+
+import com.dooingle.domain.catch.dto.AddCatchRequest
+import com.dooingle.domain.catch.dto.CatchResponse
+import com.dooingle.domain.catch.dto.DeleteCatchRequest
+import com.dooingle.domain.catch.repository.CatchRepository
+import com.dooingle.domain.dooingle.repository.DooingleRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CatchService (
+    private val dooingleRepository: DooingleRepository,
+    private val catchRepository: CatchRepository
+){
+    // 캐치 생성
+    @Transactional
+    fun addCatch(dooingleId: Long, addCatchRequest: AddCatchRequest): CatchResponse {
+        val dooingle = dooingleRepository.findByIdOrNull(dooingleId) ?: throw Exception("") // TODO
+
+        // 해당 dooingle 의 주인만 catch 를 등록할 수 있다
+        if (dooingle.owner.id != addCatchRequest.ownerId) throw Exception("") // TODO
+
+        // 해당 dooingle 의 주인은 하나의 catch 만 작성 가능하다
+        else if (catchRepository.existsByDooingle(dooingle)) throw Exception("") // TODO
+
+        val catch = addCatchRequest.to(dooingle)
+        catchRepository.save(catch)
+
+        return CatchResponse.from(catch)
+    }
+
+    // 캐치 삭제
+    @Transactional
+    fun deleteCatch(dooingleId: Long, catchId: Long, deleteCatchRequest: DeleteCatchRequest) {
+        val dooingle = dooingleRepository.findByIdOrNull(dooingleId) ?: throw Exception("") // TODO
+
+        // 해당 dooingle 의 주인만 catch 를 삭제할 수 있다
+        if (dooingle.owner.id != deleteCatchRequest.ownerId) throw Exception("") // TODO
+
+        // soft delete
+        val catch = catchRepository.findByIdOrNull(catchId) ?: throw Exception("") // TODO
+        catch.updateForDelete() // Catch 의 deletedAt 에 현재 ZonedDateTime 을 대입
+    }
+}

--- a/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
@@ -16,6 +16,7 @@ class DooingleService (
 ) {
 
     // 뒹글 생성
+    @Transactional
     fun addDooingle(ownerId: Long, addDooingleRequest: AddDooingleRequest): DooingleResponse {
         val guest = userRepository.findByIdOrNull(addDooingleRequest.guestId) ?: throw Exception("") // TODO
         val owner = userRepository.findByIdOrNull(ownerId) ?: throw Exception("") // TODO


### PR DESCRIPTION
## 연관 이슈
- closes #15 

## 해당 작업을 한 동기/이유는 무엇인가요?
- 캐치 등록,삭제 기능 구현
- 실제 삭제가 아닌 소프트딜리트로 구현(딜리트 타임 업데이트)
- 오너아이디는 추후 로그인 구현 후 수정예정

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [ ] 캐치 등록 기능구현
    - 뒹글오너와 캐치등록자가 일치할 경우만 등록가능
- [ ] 캐치 삭제 기능 구현
    - 소프트딜리트: 컨텐트보존, 딜리트 타임 업데이트를 통해 삭제 여부 판단