### PR TITLE
Feat: 새로운 뒹글러 목록 조회

### DIFF
--- a/src/main/kotlin/com/dooingle/domain/dooinglecount/repository/DooingleCountQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooinglecount/repository/DooingleCountQueryDslRepositoryImpl.kt
@@ -1,13 +1,15 @@
 package com.dooingle.domain.dooinglecount.repository
 
+import com.dooingle.domain.dooinglecount.model.QDooingleCount
 import com.dooingle.domain.user.dto.DooinglerResponse
-import com.dooingle.domain.user.model.QDooingleCount
 import com.dooingle.domain.user.model.QUser
+import com.dooingle.global.property.DooinglersProperties
 import com.querydsl.core.types.Projections
 import com.querydsl.jpa.impl.JPAQueryFactory
 
 class DooingleCountQueryDslRepositoryImpl(
-    private val queryFactory: JPAQueryFactory
+    private val queryFactory: JPAQueryFactory,
+    private val dooinglerListProperties: DooinglersProperties
 ) : DooingleCountQueryDslRepository {
 
     private val user = QUser.user
@@ -25,7 +27,7 @@ class DooingleCountQueryDslRepositoryImpl(
             .from(dooingleCount)
             .leftJoin(dooingleCount.owner, user)
             .orderBy(dooingleCount.count.desc())
-            .limit(5)
+            .limit(dooinglerListProperties.hot.toLong())
             .fetch()
     }
 

--- a/src/main/kotlin/com/dooingle/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/dooingle/domain/user/controller/UserController.kt
@@ -14,7 +14,7 @@ class UserController(
     private val userService: UserService
 ) {
     @GetMapping
-    fun GetDooinglerList(@RequestParam(required = false) condition: String?): ResponseEntity<List<DooinglerResponse>> {
+    fun GetDooinglerList(@RequestParam condition: String?): ResponseEntity<List<DooinglerResponse>> {
         return ResponseEntity.ok().body(userService.getDooinglerList(condition))
     }
 }

--- a/src/main/kotlin/com/dooingle/domain/user/repository/UserQueryDslRepository.kt
+++ b/src/main/kotlin/com/dooingle/domain/user/repository/UserQueryDslRepository.kt
@@ -1,0 +1,7 @@
+package com.dooingle.domain.user.repository
+
+import com.dooingle.domain.user.dto.DooinglerResponse
+
+interface UserQueryDslRepository {
+    fun getNewDooinglers(): List<DooinglerResponse>
+}

--- a/src/main/kotlin/com/dooingle/domain/user/repository/UserQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/dooingle/domain/user/repository/UserQueryDslRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package com.dooingle.domain.user.repository
+
+import com.dooingle.domain.user.dto.DooinglerResponse
+import com.dooingle.domain.user.model.QUser
+import com.dooingle.global.property.DooinglersProperties
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+
+class UserQueryDslRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+    private val dooinglerListProperties: DooinglersProperties
+) : UserQueryDslRepository {
+
+    private val user = QUser.user
+
+    override fun getNewDooinglers(): List<DooinglerResponse> {
+        return queryFactory.select(
+            Projections.constructor(
+                DooinglerResponse::class.java,
+                user.id,
+                user.name
+            )
+        )
+            .from(user)
+            .orderBy(user.id.desc())
+            .limit(dooinglerListProperties.new.toLong())
+            .fetch()
+    }
+
+}

--- a/src/main/kotlin/com/dooingle/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/dooingle/domain/user/repository/UserRepository.kt
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface UserRepository : JpaRepository<User, Long>{
+interface UserRepository : JpaRepository<User, Long>, UserQueryDslRepository {
 }

--- a/src/main/kotlin/com/dooingle/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/dooingle/domain/user/service/UserService.kt
@@ -2,16 +2,19 @@ package com.dooingle.domain.user.service
 
 import com.dooingle.domain.dooinglecount.service.DooingleCountService
 import com.dooingle.domain.user.dto.DooinglerResponse
+import com.dooingle.domain.user.repository.UserRepository
 import org.springframework.stereotype.Service
 
 @Service
 class UserService(
+    private val userRepository: UserRepository,
     private val dooingleCountService: DooingleCountService
 ) {
     fun getDooinglerList(condition: String?): List<DooinglerResponse> {
         return when (condition) {
             "hot" -> dooingleCountService.getHotDooinglerList()
-            else -> TODO("새 뒹글러 목록 조회")
+            "new" -> userRepository.getNewDooinglers()
+            else -> throw IllegalArgumentException() // TODO
         }
     }
 

--- a/src/main/kotlin/com/dooingle/global/property/DooinglersProperties.kt
+++ b/src/main/kotlin/com/dooingle/global/property/DooinglersProperties.kt
@@ -1,0 +1,9 @@
+package com.dooingle.global.property
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "dooingler.list.size")
+class DooinglersProperties(
+    val hot: Int,
+    val new: Int
+)

--- a/src/main/kotlin/com/dooingle/global/property/PropertyConfig.kt
+++ b/src/main/kotlin/com/dooingle/global/property/PropertyConfig.kt
@@ -1,0 +1,8 @@
+package com.dooingle.global.property
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@EnableConfigurationProperties(DooinglersProperties::class)
+@Configuration
+class PropertyConfig

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -21,3 +21,9 @@ logging:
     'org.hibernate.SQL': debug
     'org.hibernate.orm.jdbc.bind': trace
     #'org.springframework.security.web.FilterChainProxy': debug
+
+dooingler:
+  list:
+    size:
+      hot: 5
+      new: 5


### PR DESCRIPTION
## 연관 이슈
- closes #20 

## 해당 작업을 한 동기/이유는 무엇인가요?
- 새로 가입한 뒹글러 목록을 보여주는 기능을 구현했습니다.

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] 새로운 뒹글러 목록 조회 기능 구현
  - id 역순으로 property size만큼 뒹글러 목록 조회
  - 컨트롤러 RequestParam 필수 기재로 변경
  - hot과 new가 아닌 경우 예외 발생
- [x] Configuration properties 추가
  - EnableConfigurationProperties Configuration 추가
  - 뒹글러 목록 개수 ConfigurationProperties 추가
- [x] QDooingleCount 위치 오류 수정