### PR TITLE
Feat: 내 뒹글의 캐치에 대한 알림, 피드 새 게시글 알림

### DIFF
--- a/dooingle-front/src/pages/Feed.jsx
+++ b/dooingle-front/src/pages/Feed.jsx
@@ -10,6 +10,7 @@ const BASE_URL = "http://localhost:8080"
 export default function FeedPage() {
 
   const [notification, setNotification] = useState(null);
+  const [feed, setFeed] = useState(null);
 
   const handleConnect = () => {
 
@@ -30,6 +31,15 @@ export default function FeedPage() {
 
       // 전달받는 텍스트 데이터는 메세지-dooingleId 형식. 예) 새로운 뒹글이 굴러왔어요!-5
       // TODO : 이벤트 발생 시 알림 팝업 띄워서 메세지 보여주고, 팝업 클릭 시 UserDooingle 페이지로 이동(cursor로 dooingleId 보내기)
+    });
+
+    sse.addEventListener('feed', e => {
+      const { data: receivedFeed } = e;
+
+      console.log(receivedFeed);
+      setFeed(receivedFeed)
+
+      // TODO : 피드 새로운 글 알림(새로고침이나 화살표 같은..) 버튼을 위에 뜨게 함
     });
   }
 
@@ -114,6 +124,7 @@ export default function FeedPage() {
 
           <button onClick={handleConnect}>connect 요청</button>
           <div>{notification}</div>
+          <div>{feed}</div>
           <button onClick={handleTestConnect}>test connect 요청</button>
           <button onClick={handleTestClick}>test 요청</button>
           <div>{testData}</div>

--- a/src/main/kotlin/com/dooingle/domain/catch/service/CatchService.kt
+++ b/src/main/kotlin/com/dooingle/domain/catch/service/CatchService.kt
@@ -42,9 +42,11 @@ class CatchService (
                 notificationType = NotificationType.CATCH,
                 resourceId = dooingleId
             )
-        )
-            .let { NotificationResponse.from(it) }
-            .let { sseEmitters.sendNotification(dooingle.owner.id!!, "${it.message}-${it.cursor}") }
+        ).let {
+            NotificationResponse.from(it)
+        }.let {
+            sseEmitters.sendUserNotification(dooingle.owner.id!!, "${it.message}-${it.cursor}")
+        }
 
         return CatchResponse.from(catch)
     }

--- a/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
@@ -9,13 +9,9 @@ import com.dooingle.domain.dooingle.model.Dooingle
 import com.dooingle.domain.dooingle.repository.DooingleRepository
 import com.dooingle.domain.dooinglecount.model.DooingleCount
 import com.dooingle.domain.dooinglecount.repository.DooingleCountRepository
-import com.dooingle.domain.notification.NotificationRepository
-import com.dooingle.domain.notification.dto.NotificationResponse
-import com.dooingle.domain.notification.model.Notification
-import com.dooingle.domain.notification.model.NotificationType
+import com.dooingle.domain.notification.service.NotificationService
 import com.dooingle.domain.user.repository.SocialUserRepository
 import com.dooingle.global.security.UserPrincipal
-import com.dooingle.global.sse.SseEmitters
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
 import org.springframework.data.repository.findByIdOrNull
@@ -28,8 +24,7 @@ class DooingleService(
     private val socialUserRepository: SocialUserRepository,
     private val catchRepository: CatchRepository,
     private val dooingleCountRepository: DooingleCountRepository,
-    private val sseEmitters: SseEmitters,
-    private val notificationRepository: NotificationRepository
+    private val notificationService: NotificationService
 ) {
     companion object {
         const val USER_FEED_PAGE_SIZE = 5
@@ -54,18 +49,7 @@ class DooingleService(
             ?: dooingleCountRepository.save(DooingleCount(owner = owner))
         dooingleCount.plus()
 
-        notificationRepository.save(
-            Notification(
-                user = owner,
-                notificationType = NotificationType.DOOINGLE,
-                resourceId = dooingle.id!!
-            )
-        ).let {
-            NotificationResponse.from(it)
-        }.let {
-            sseEmitters.sendUserNotification(ownerId, "${it.message}-${it.cursor}")
-            sseEmitters.sendNewFeedNotification()
-        }
+        notificationService.addDooingleNotification(user = owner, dooingleId = dooingle.id!!)
 
         return DooingleResponse.from(dooingle)
     }

--- a/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
@@ -60,9 +60,12 @@ class DooingleService(
                 notificationType = NotificationType.DOOINGLE,
                 resourceId = dooingle.id!!
             )
-        )
-            .let { NotificationResponse.from(it) }
-            .let { sseEmitters.sendNotification(ownerId, "${it.message}-${it.cursor}") }
+        ).let {
+            NotificationResponse.from(it)
+        }.let {
+            sseEmitters.sendUserNotification(ownerId, "${it.message}-${it.cursor}")
+            sseEmitters.sendNewFeedNotification()
+        }
 
         return DooingleResponse.from(dooingle)
     }

--- a/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationRepository.kt
@@ -1,4 +1,4 @@
-package com.dooingle.domain.notification
+package com.dooingle.domain.notification.repository
 
 import com.dooingle.domain.notification.model.Notification
 import org.springframework.data.jpa.repository.JpaRepository

--- a/src/main/kotlin/com/dooingle/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/service/NotificationService.kt
@@ -1,14 +1,47 @@
 package com.dooingle.domain.notification.service
 
+import com.dooingle.domain.notification.dto.NotificationResponse
+import com.dooingle.domain.notification.model.Notification
+import com.dooingle.domain.notification.model.NotificationType
+import com.dooingle.domain.notification.repository.NotificationRepository
+import com.dooingle.domain.user.model.SocialUser
 import com.dooingle.global.sse.SseEmitters
 import org.springframework.stereotype.Service
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 
 @Service
 class NotificationService(
-    private val sseEmitters: SseEmitters
+    private val sseEmitters: SseEmitters,
+    private val notificationRepository: NotificationRepository
 ) {
     fun connect(userId: Long): SseEmitter {
         return sseEmitters.addWith(userId)
     }
+
+    fun addDooingleNotification(user: SocialUser, dooingleId: Long) {
+        addAndSendNotification(user, NotificationType.DOOINGLE, dooingleId)
+            .also { sseEmitters.sendNewFeedNotification() }
+    }
+
+    fun addCatchNotification(user: SocialUser, dooingleId: Long) {
+        addAndSendNotification(user, NotificationType.CATCH, dooingleId)
+    }
+
+    fun addAndSendNotification(user: SocialUser, type: NotificationType, dooingleId: Long) {
+        notificationRepository.save(
+            Notification(
+                user = user,
+                notificationType = type,
+                resourceId = dooingleId
+            )
+        ).let {
+            NotificationResponse.from(it)
+        }.let { response ->
+            sseEmitters.sendUserNotification(
+                userId = user.id!!,
+                data = "${response.message}-${response.cursor}"
+            )
+        }
+    }
+
 }

--- a/src/main/kotlin/com/dooingle/global/sse/SseEmitters.kt
+++ b/src/main/kotlin/com/dooingle/global/sse/SseEmitters.kt
@@ -48,9 +48,9 @@ class SseEmitters {
         return emitter
     }
 
-    fun sendUserNotification(userId: Long, notification: String) {
+    fun sendUserNotification(userId: Long, data: Any) {
         notificationEmitters[userId.toString()]?.forEach { emitter ->
-            emitter.sendData(eventName = "notification", data = notification)
+            emitter.sendData(eventName = "notification", data = data)
         }
     }
 

--- a/src/main/kotlin/com/dooingle/global/sse/SseEmitters.kt
+++ b/src/main/kotlin/com/dooingle/global/sse/SseEmitters.kt
@@ -48,9 +48,17 @@ class SseEmitters {
         return emitter
     }
 
-    fun sendNotification(userId: Long, notification: String) {
+    fun sendUserNotification(userId: Long, notification: String) {
         notificationEmitters[userId.toString()]?.forEach { emitter ->
             emitter.sendData(eventName = "notification", data = notification)
+        }
+    }
+
+    fun sendNewFeedNotification() {
+        notificationEmitters.forEach { key, list ->
+            list.forEach { emitter ->
+                emitter.sendData(eventName = "feed", data = "new feed")
+            }
         }
     }
 


### PR DESCRIPTION
## 연관 이슈
- closes #60, #62 

## 해당 작업을 한 동기/이유는 무엇인가요?
- 내가 굴린 뒹글에 캐치가 달린 경우 알리는 기능, 피드에 새 게시물이 올라오는 경우 알리는 기능을 구현했습니다.

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] 캐치 등록 시 알림 테이블에 저장, SSE 전송
  - 뒹글과 마찬가지로 브라우저에 notification라는 이름의 이벤트로 알림 전송
  - 같은 유저 아이디로 SSE 연결된 모든 브라우저에 알림 전송
- [x] 피드 새 게시글 알림
  - 뒹글 등록 시 SSE 연결된 모든 브라우저에 알림 전송
  - 구분 위해 기존 알림 메서드명 sendUserNotification으로 변경하고, 해당 메서드는 sendNewFeedNotification으로 작성
  - 이슈 등록 당시 따로 list를 만들어 SseEmitter들을 저장하기로 했으나, 기존 concurrentHashMap을 사용하는 방식으로 구현
- [x] (프론트) 피드 새 게시글 알림
  - feed 이벤트리스너 등록
- [x] 의존 관계 수정
  - DooingleService와 CatchService에서 NotificationRepository, SseEmitters 의존 제거
  - NotificationService에서 NofiticationRepository와 SseEmitters 의존