### PR TITLE
feat:지난 알림 조회 기능 구현

### DIFF
--- a/src/main/kotlin/com/dooingle/domain/catchdomain/service/CatchService.kt
+++ b/src/main/kotlin/com/dooingle/domain/catchdomain/service/CatchService.kt
@@ -31,7 +31,7 @@ class CatchService (
         dooingle.catch = catch
         catchRepository.save(catch)
 
-        notificationService.addCatchNotification(user = dooingle.owner, dooingleId = dooingleId)
+        notificationService.addCatchNotification(user = dooingle.guest, dooingleId = dooingleId)
 
         return CatchResponse.from(catch)
     }

--- a/src/main/kotlin/com/dooingle/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/controller/NotificationController.kt
@@ -1,8 +1,14 @@
 package com.dooingle.domain.notification.controller
 
+import com.dooingle.domain.notification.dto.NotificationResponse
 import com.dooingle.domain.notification.service.NotificationService
+import com.dooingle.global.security.UserPrincipal
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.data.domain.Slice
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -21,6 +27,17 @@ class NotificationController(
     ): ResponseEntity<SseEmitter> {
         val emitter = notificationService.connect(userId)
         return ResponseEntity.ok(emitter)
+    }
+
+    @Operation(summary = "지난 알림 조회")
+    @GetMapping
+    fun fastNotifications(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        cursor: Long?
+    ): ResponseEntity<Slice<NotificationResponse>>{
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(notificationService.getNotifications(userPrincipal, cursor))
     }
 
 }

--- a/src/main/kotlin/com/dooingle/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/controller/NotificationController.kt
@@ -31,13 +31,13 @@ class NotificationController(
 
     @Operation(summary = "지난 알림 조회")
     @GetMapping
-    fun fastNotifications(
+    fun findPastNotifications(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         cursor: Long?
     ): ResponseEntity<Slice<NotificationResponse>>{
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(notificationService.getNotifications(userPrincipal, cursor))
+            .body(notificationService.getNotifications(userPrincipal.id, cursor))
     }
 
 }

--- a/src/main/kotlin/com/dooingle/domain/notification/dto/NotificationQueryResponse.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/dto/NotificationQueryResponse.kt
@@ -1,0 +1,21 @@
+package com.dooingle.domain.notification.dto
+
+import com.dooingle.domain.notification.model.NotificationType
+
+data class NotificationQueryResponse(
+    val notificationType: NotificationType,
+    val cursor: Long
+) {
+    companion object {
+        private const val NEW_DOOINGLE = "새로운 뒹글이 굴러왔어요!"
+        private const val NEW_CATCH = "내가 굴린 뒹글에 캐치가 달렸어요!"
+
+        fun toResponse(notificationQueryResponse: NotificationQueryResponse) = NotificationResponse(
+            message = when (notificationQueryResponse.notificationType) {
+                NotificationType.DOOINGLE -> NEW_DOOINGLE
+                NotificationType.CATCH -> NEW_CATCH
+            },
+            cursor = notificationQueryResponse.cursor
+        )
+    }
+}

--- a/src/main/kotlin/com/dooingle/domain/notification/dto/NotificationResponse.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/dto/NotificationResponse.kt
@@ -1,22 +1,6 @@
 package com.dooingle.domain.notification.dto
 
-import com.dooingle.domain.notification.model.Notification
-import com.dooingle.domain.notification.model.NotificationType
-
 data class NotificationResponse(
-    val message: String,
+    val notificationType: String,
     val cursor: Long
-) {
-    companion object {
-        private const val NEW_DOOINGLE = "새로운 뒹글이 굴러왔어요!"
-        private const val NEW_CATCH = "내가 굴린 뒹글에 캐치가 달렸어요!"
-
-        fun from(notification: Notification) = NotificationResponse(
-            message = when (notification.notificationType) {
-                NotificationType.DOOINGLE -> NEW_DOOINGLE
-                NotificationType.CATCH -> NEW_CATCH
-            },
-            cursor = notification.resourceId
-        )
-    }
-}
+)

--- a/src/main/kotlin/com/dooingle/domain/notification/dto/NotificationSseResponse.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/dto/NotificationSseResponse.kt
@@ -1,21 +1,22 @@
 package com.dooingle.domain.notification.dto
 
+import com.dooingle.domain.notification.model.Notification
 import com.dooingle.domain.notification.model.NotificationType
 
-data class NotificationQueryResponse(
-    val notificationType: NotificationType,
+data class NotificationSseResponse(
+    val message: String,
     val cursor: Long
 ) {
     companion object {
         private const val NEW_DOOINGLE = "새로운 뒹글이 굴러왔어요!"
         private const val NEW_CATCH = "내가 굴린 뒹글에 캐치가 달렸어요!"
 
-        fun toResponse(notificationQueryResponse: NotificationQueryResponse) = NotificationResponse(
-            message = when (notificationQueryResponse.notificationType) {
+        fun from(notification: Notification) = NotificationSseResponse(
+            message = when (notification.notificationType) {
                 NotificationType.DOOINGLE -> NEW_DOOINGLE
                 NotificationType.CATCH -> NEW_CATCH
             },
-            cursor = notificationQueryResponse.cursor
+            cursor = notification.resourceId
         )
     }
 }

--- a/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationQueryDslRepository.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationQueryDslRepository.kt
@@ -1,0 +1,10 @@
+package com.dooingle.domain.notification.repository
+
+import com.dooingle.domain.notification.dto.NotificationQueryResponse
+import com.dooingle.domain.user.model.SocialUser
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+
+interface NotificationQueryDslRepository {
+    fun getNotificationBySlice(user: SocialUser, cursor: Long?, pageable: Pageable): Slice<NotificationQueryResponse>
+}

--- a/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationQueryDslRepository.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationQueryDslRepository.kt
@@ -1,10 +1,10 @@
 package com.dooingle.domain.notification.repository
 
-import com.dooingle.domain.notification.dto.NotificationQueryResponse
+import com.dooingle.domain.notification.dto.NotificationResponse
 import com.dooingle.domain.user.model.SocialUser
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
 interface NotificationQueryDslRepository {
-    fun getNotificationBySlice(user: SocialUser, cursor: Long?, pageable: Pageable): Slice<NotificationQueryResponse>
+    fun getNotificationBySlice(user: SocialUser, cursor: Long?, pageable: Pageable): Slice<NotificationResponse>
 }

--- a/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationQueryDslRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.dooingle.domain.notification.repository
 
-import com.dooingle.domain.notification.dto.NotificationQueryResponse
+import com.dooingle.domain.notification.dto.NotificationResponse
 import com.dooingle.domain.notification.model.QNotification
 import com.dooingle.domain.user.model.QSocialUser
 import com.dooingle.domain.user.model.SocialUser
@@ -23,7 +23,7 @@ class NotificationQueryDslRepositoryImpl(
         user: SocialUser,
         cursor: Long?,
         pageable: Pageable
-    ): Slice<NotificationQueryResponse> {
+    ): Slice<NotificationResponse> {
         val selectSize = pageable.pageSize + 1
         val whereClause = BooleanBuilder()
             .and(lessThanCursor(cursor))
@@ -38,14 +38,14 @@ class NotificationQueryDslRepositoryImpl(
 
     private fun lessThanCursor(cursor: Long?) = cursor?.let { notification.id.lt(it) }
 
-    private fun hasNextSlice(list: List<NotificationQueryResponse>, selectSize: Int) = (list.size == selectSize)
+    private fun hasNextSlice(list: List<NotificationResponse>, selectSize: Int) = (list.size == selectSize)
 
     private fun getContents(whereClause: BooleanBuilder, selectSize: Long) =
         queryFactory
             .select(
                 Projections.constructor(
-                    NotificationQueryResponse::class.java,
-                    notification.notificationType,
+                    NotificationResponse::class.java,
+                    notification.notificationType.stringValue(),
                     notification.resourceId
                 )
             ).from(notification)

--- a/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationQueryDslRepositoryImpl.kt
@@ -1,0 +1,57 @@
+package com.dooingle.domain.notification.repository
+
+import com.dooingle.domain.notification.dto.NotificationQueryResponse
+import com.dooingle.domain.notification.model.QNotification
+import com.dooingle.domain.user.model.QSocialUser
+import com.dooingle.domain.user.model.SocialUser
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
+import org.springframework.data.domain.SliceImpl
+import org.springframework.stereotype.Repository
+
+@Repository
+class NotificationQueryDslRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : NotificationQueryDslRepository{
+    private val notification = QNotification.notification
+    private val user = QSocialUser.socialUser
+
+    override fun getNotificationBySlice(
+        user: SocialUser,
+        cursor: Long?,
+        pageable: Pageable
+    ): Slice<NotificationQueryResponse> {
+        val selectSize = pageable.pageSize + 1
+        val whereClause = BooleanBuilder()
+            .and(lessThanCursor(cursor))
+            .and(notification.user.eq(user))
+        val list = getContents(whereClause, selectSize.toLong())
+
+        return SliceImpl(
+            if (list.size < selectSize) list else list.dropLast(1),
+            pageable,
+            hasNextSlice(list, selectSize))
+    }
+
+    private fun lessThanCursor(cursor: Long?) = cursor?.let { notification.id.lt(it) }
+
+    private fun hasNextSlice(list: List<NotificationQueryResponse>, selectSize: Int) = (list.size == selectSize)
+
+    private fun getContents(whereClause: BooleanBuilder, selectSize: Long) =
+        queryFactory
+            .select(
+                Projections.constructor(
+                    NotificationQueryResponse::class.java,
+                    notification.notificationType,
+                    notification.resourceId
+                )
+            ).from(notification)
+            .join(notification.user, user)
+            .where(whereClause)
+            .orderBy(notification.id.desc())
+            .limit(selectSize)
+            .fetch()
+}

--- a/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationRepository.kt
@@ -1,7 +1,11 @@
 package com.dooingle.domain.notification.repository
 
 import com.dooingle.domain.notification.model.Notification
+import com.dooingle.domain.user.model.SocialUser
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
-interface NotificationRepository : JpaRepository<Notification, Long> {
+@Repository
+interface NotificationRepository : JpaRepository<Notification, Long>, NotificationQueryDslRepository {
+    fun findAllByUser(user: SocialUser): List<Notification>
 }

--- a/src/main/kotlin/com/dooingle/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/service/NotificationService.kt
@@ -7,6 +7,8 @@ import com.dooingle.domain.notification.model.NotificationType
 import com.dooingle.domain.notification.repository.NotificationRepository
 import com.dooingle.domain.user.model.SocialUser
 import com.dooingle.domain.user.repository.SocialUserRepository
+import com.dooingle.global.exception.custom.ModelNotFoundException
+import com.dooingle.global.security.UserPrincipal
 import com.dooingle.global.sse.SseEmitters
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
@@ -54,8 +56,9 @@ class NotificationService(
         }
     }
 
-    fun getNotifications(userId: Long, cursor: Long?): Slice<NotificationResponse> {
-        val user = socialUserRepository.findByIdOrNull(userId)?: throw Exception("")
+    fun getNotifications(userPrincipal: UserPrincipal, cursor: Long?): Slice<NotificationResponse> {
+        val user = socialUserRepository.findByIdOrNull(userPrincipal.id)
+            ?: throw ModelNotFoundException(modelName = "Social User", modelId = userPrincipal.id)
         val pageRequest = PageRequest.ofSize(NOTIFICATION_PAGE_SIZE)
 
         return notificationRepository.getNotificationBySlice(user, cursor, pageRequest)

--- a/src/main/kotlin/com/dooingle/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/service/NotificationService.kt
@@ -1,14 +1,12 @@
 package com.dooingle.domain.notification.service
 
-import com.dooingle.domain.dooingle.service.DooingleService
-import com.dooingle.domain.notification.dto.NotificationQueryResponse
 import com.dooingle.domain.notification.dto.NotificationResponse
+import com.dooingle.domain.notification.dto.NotificationSseResponse
 import com.dooingle.domain.notification.model.Notification
 import com.dooingle.domain.notification.model.NotificationType
 import com.dooingle.domain.notification.repository.NotificationRepository
 import com.dooingle.domain.user.model.SocialUser
 import com.dooingle.domain.user.repository.SocialUserRepository
-import com.dooingle.global.security.UserPrincipal
 import com.dooingle.global.sse.SseEmitters
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
@@ -47,7 +45,7 @@ class NotificationService(
                 resourceId = dooingleId
             )
         ).let {
-            NotificationResponse.from(it)
+            NotificationSseResponse.from(it)
         }.let { response ->
             sseEmitters.sendUserNotification(
                 userId = user.id!!,
@@ -56,12 +54,11 @@ class NotificationService(
         }
     }
 
-    fun getNotifications(userPrincipal: UserPrincipal, cursor: Long?): Slice<NotificationResponse> {
-        val user = socialUserRepository.findByIdOrNull(userPrincipal.id)?: throw Exception("")
+    fun getNotifications(userId: Long, cursor: Long?): Slice<NotificationResponse> {
+        val user = socialUserRepository.findByIdOrNull(userId)?: throw Exception("")
         val pageRequest = PageRequest.ofSize(NOTIFICATION_PAGE_SIZE)
 
         return notificationRepository.getNotificationBySlice(user, cursor, pageRequest)
-            .map { NotificationQueryResponse.toResponse(it) }
     }
 
 }

--- a/src/main/kotlin/com/dooingle/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/service/NotificationService.kt
@@ -1,19 +1,31 @@
 package com.dooingle.domain.notification.service
 
+import com.dooingle.domain.dooingle.service.DooingleService
+import com.dooingle.domain.notification.dto.NotificationQueryResponse
 import com.dooingle.domain.notification.dto.NotificationResponse
 import com.dooingle.domain.notification.model.Notification
 import com.dooingle.domain.notification.model.NotificationType
 import com.dooingle.domain.notification.repository.NotificationRepository
 import com.dooingle.domain.user.model.SocialUser
+import com.dooingle.domain.user.repository.SocialUserRepository
+import com.dooingle.global.security.UserPrincipal
 import com.dooingle.global.sse.SseEmitters
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Slice
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 
 @Service
 class NotificationService(
     private val sseEmitters: SseEmitters,
+    private val socialUserRepository: SocialUserRepository,
     private val notificationRepository: NotificationRepository
 ) {
+    companion object {
+        const val NOTIFICATION_PAGE_SIZE = 10
+    }
+
     fun connect(userId: Long): SseEmitter {
         return sseEmitters.addWith(userId)
     }
@@ -42,6 +54,14 @@ class NotificationService(
                 data = "${response.message}-${response.cursor}"
             )
         }
+    }
+
+    fun getNotifications(userPrincipal: UserPrincipal, cursor: Long?): Slice<NotificationResponse> {
+        val user = socialUserRepository.findByIdOrNull(userPrincipal.id)?: throw Exception("")
+        val pageRequest = PageRequest.ofSize(NOTIFICATION_PAGE_SIZE)
+
+        return notificationRepository.getNotificationBySlice(user, cursor, pageRequest)
+            .map { NotificationQueryResponse.toResponse(it) }
     }
 
 }

--- a/src/main/kotlin/com/dooingle/domain/user/controller/OAuth2LoginController.kt
+++ b/src/main/kotlin/com/dooingle/domain/user/controller/OAuth2LoginController.kt
@@ -23,6 +23,7 @@ class OAuth2LoginController(
         response.sendRedirect(loginPageUrl)
     }
 
+
     @GetMapping("/callback/{provider}")
     fun callback(
         @PathVariable provider: OAuth2Provider,


### PR DESCRIPTION
## 연관 이슈
- closes #71 

## 해당 작업을 한 동기/이유는 무엇인가요?
- 지난 알림 조회 기능 구현

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [ ] 지난 알림 조회 기능 구현
    - 커서기반 페이지 네이션 적용
- [ ] 스웨거 테스트 중 캐치 서비스에서 알람 대상 오류 발견, 픽스 (오너에서 게스트로 변경)
    -  notificationService.addCatchNotification(user = dooingle.guest, dooingleId = dooingleId)