### PR TITLE
Feat: 팔로우 피드 기능 추가, 기존 피드 메서드 리팩토링

### DIFF
--- a/src/main/kotlin/com/dooingle/domain/dooingle/controller/DooingleFeedController.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/controller/DooingleFeedController.kt
@@ -2,9 +2,11 @@ package com.dooingle.domain.dooingle.controller
 
 import com.dooingle.domain.dooingle.dto.DooingleResponse
 import com.dooingle.domain.dooingle.service.DooingleService
+import com.dooingle.global.security.UserPrincipal
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Slice
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -16,17 +18,19 @@ class DooingleFeedController(
 ) {
 
     @GetMapping
-    fun getDooingleFeeds(cursor: Long?): ResponseEntity<Slice<DooingleResponse>> {
+    fun getDooingleFeed(cursor: Long?): ResponseEntity<Slice<DooingleResponse>> {
         val pageRequest = PageRequest.ofSize(PAGE_SIZE)
-        return ResponseEntity.ok(dooingleService.getDooingleFeeds(cursor, pageRequest))
+        return ResponseEntity.ok(dooingleService.getDooingleFeed(cursor, pageRequest))
     }
 
-    // TODO 팔로우 기능 구현 후 구현 필요
-//    @GetMapping("/follow")
-//    fun getDooingleFeedsOfFollows(cursor: Long): ResponseEntity<Slice<DooingleResponse>> {
-//        val pageRequest = PageRequest.ofSize(PAGE_SIZE)
-//        return ResponseEntity.ok(dooingleService.getDooingleFeedsOfFollows(cursor, pageRequest))
-//    }
+    @GetMapping("/follow")
+    fun getDooingleFeedOfFollowing(
+        @AuthenticationPrincipal userPrincipal: UserPrincipal,
+        cursor: Long?
+    ): ResponseEntity<Slice<DooingleResponse>> {
+        val pageRequest = PageRequest.ofSize(PAGE_SIZE)
+        return ResponseEntity.ok(dooingleService.getDooingleFeedOfFollowing(userPrincipal.id, cursor, pageRequest))
+    }
 
     companion object {
         const val PAGE_SIZE = 20

--- a/src/main/kotlin/com/dooingle/domain/dooingle/repository/DooingleQueryDslRepository.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/repository/DooingleQueryDslRepository.kt
@@ -10,8 +10,8 @@ interface DooingleQueryDslRepository {
 
     fun getDooinglesBySlice(cursor: Long?, pageable: Pageable): Slice<DooingleResponse>
 
+    fun getDooinglesFollowingBySlice(userId: Long, cursor: Long?, pageable: Pageable): Slice<DooingleResponse>
+
     fun getPersonalPageBySlice(owner: SocialUser, cursor: Long?, pageable: Pageable): Slice<DooingleAndCatchResponse>
 
-    // TODO 팔로우 기능 구현 후 구현 필요
-    // fun getDooinglePageableOfFollows(pageable: Pageable): Slice<Dooingle>
 }

--- a/src/main/kotlin/com/dooingle/domain/dooingle/repository/DooingleQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/repository/DooingleQueryDslRepositoryImpl.kt
@@ -44,11 +44,7 @@ class DooingleQueryDslRepositoryImpl(
             .limit(selectSize.toLong())
             .fetch()
             .let {
-                SliceImpl(
-                    if (it.size < selectSize) it else it.dropLast(1),
-                    pageable,
-                    hasNextSlice(it, selectSize)
-                )
+                changeToSlice(it, selectSize, pageable)
             }
     }
 
@@ -78,11 +74,7 @@ class DooingleQueryDslRepositoryImpl(
             .limit(selectSize.toLong())
             .fetch()
             .let {
-                SliceImpl(
-                    if (it.size < selectSize) it else it.dropLast(1),
-                    pageable,
-                    hasNextSlice(it, selectSize)
-                )
+                changeToSlice(it, selectSize, pageable)
             }
     }
 
@@ -92,17 +84,19 @@ class DooingleQueryDslRepositoryImpl(
             .and(lessThanCursor(cursor))
             .and(dooingle.owner.eq(owner))
         val list = getContents(whereClause, pageable)
-
-        return SliceImpl(
-            if (list.size < selectSize) list else list.dropLast(1),
-            pageable,
-            hasNextSliceBySlice(list, selectSize))
+        return changeToSlice(list, selectSize, pageable)
     }
 
     private fun lessThanCursor(cursor: Long?) = cursor?.let { dooingle.id.lt(it) }
 
-    private fun hasNextSlice(dooingleList: List<DooingleResponse>, selectSize: Int) = (dooingleList.size == selectSize)
-    private fun hasNextSliceBySlice(dooingleList: List<DooingleAndCatchResponse>, selectSize: Int) = (dooingleList.size == selectSize)
+    private fun <T> hasNextSlice(dooingleList: List<T>, selectSize: Int) = (dooingleList.size == selectSize)
+
+    private fun <T> changeToSlice(list: List<T>, selectSize: Int, pageable: Pageable) =
+        SliceImpl(
+            if (list.size < selectSize) list else list.dropLast(1),
+            pageable,
+            hasNextSlice(list, selectSize)
+        )
 
     private fun getContents(whereClause: BooleanBuilder, pageable: Pageable) =
         queryFactory
@@ -128,4 +122,5 @@ class DooingleQueryDslRepositoryImpl(
             .orderBy(dooingle.id.desc())
             .limit((pageable.pageSize + 1).toLong())
             .fetch()
+
 }

--- a/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
@@ -67,16 +67,20 @@ class DooingleService(
         return dooingleRepository.getPersonalPageBySlice(owner, cursor, pageRequest)
     }
 
+    fun getDooingleFeed(cursor: Long?, pageRequest: PageRequest): Slice<DooingleResponse> {
+        return dooingleRepository.getDooinglesBySlice(cursor, pageRequest)
+    }
+
+    fun getDooingleFeedOfFollowing(userId: Long, cursor: Long?, pageRequest: PageRequest): Slice<DooingleResponse> {
+        return dooingleRepository.getDooinglesFollowingBySlice(userId, cursor, pageRequest)
+    }
+
     // 단일 뒹글 조회(글자수 제한 정책으로 실제 사용되지는 않지만 정책수정을 통한 추가 기능의 확장성을 위해 남겨둠)
     fun getDooingle(userId: Long, dooingleId: Long): DooingleResponse {
         val dooingle = dooingleRepository.findByIdOrNull(dooingleId)
             ?: throw ModelNotFoundException(modelName = "Dooingle", modelId = dooingleId)
 
         return DooingleResponse.from(dooingle)
-    }
-
-    fun getDooingleFeeds(cursor: Long?, pageRequest: PageRequest): Slice<DooingleResponse> {
-        return dooingleRepository.getDooinglesBySlice(cursor, pageRequest)
     }
 
     private fun getDooingle(dooingleId: Long): Dooingle {
@@ -90,8 +94,4 @@ class DooingleService(
         return catchRepository.findByDooingle(dooingle)
     }
 
-    // TODO 팔로우 기능 구현 후 구현 필요
-//    fun getDooingleFeedsOfFollows(cursor: Long, pageRequest: PageRequest): Slice<DooingleResponse> {
-//        return
-//    }
 }

--- a/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceUnitTest.kt
+++ b/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceUnitTest.kt
@@ -192,6 +192,21 @@ class DooingleServiceUnitTest : AnnotationSpec() {
         result.content.first().dooingleId shouldBe theNextOfLatestSliceOfDooingleResponseList.first().dooingleId
     }
 
+    @Test
+    fun `팔로우 피드를 조회하면 팔로우하는 사람의 뒹글 목록만 조회한다`() {
+        // 팔로우하지 않는 사람의 뒹글은 조회되지 않아야 함
+    }
+
+    @Test
+    fun `팔로우 피드 조회 시 커서가 전달되지 않는다면 최신 글부터 조회한다`() {
+
+    }
+
+    @Test
+    fun `팔로우 피드 조회 시 커서가 전달되면 커서 이전 글부터 조회한다`() {
+
+    }
+
     private fun getFixtureOfOwner() = SocialUser(
         id = ownerId,
         provider = ownerOAuthProvider,

--- a/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceUnitTest.kt
+++ b/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceUnitTest.kt
@@ -1,11 +1,12 @@
 package com.dooingle.domain.dooingle.service
 
-import com.dooingle.domain.catch.repository.CatchRepository
+import com.dooingle.domain.catchdomain.repository.CatchRepository
 import com.dooingle.domain.dooingle.controller.DooingleFeedController
 import com.dooingle.domain.dooingle.dto.AddDooingleRequest
 import com.dooingle.domain.dooingle.dto.DooingleResponse
 import com.dooingle.domain.dooingle.repository.DooingleRepository
 import com.dooingle.domain.dooinglecount.repository.DooingleCountRepository
+import com.dooingle.domain.notification.service.NotificationService
 import com.dooingle.domain.user.model.SocialUser
 import com.dooingle.domain.user.repository.SocialUserRepository
 import com.dooingle.global.oauth2.provider.OAuth2Provider
@@ -31,11 +32,13 @@ class DooingleServiceUnitTest : AnnotationSpec() {
     private val mockSocialUserRepository = mockk<SocialUserRepository>()
     private val mockCatchRepository = mockk<CatchRepository>()
     private val mockDooingleCountRepository = mockk<DooingleCountRepository>()
+    private val mockNotificationService = mockk<NotificationService>()
     private val dooingleService = DooingleService(
         dooingleRepository = mockDooingleRepository,
         socialUserRepository = mockSocialUserRepository,
         catchRepository = mockCatchRepository,
         dooingleCountRepository = mockDooingleCountRepository,
+        notificationService = mockNotificationService
     )
 
     lateinit var owner: SocialUser
@@ -84,32 +87,32 @@ class DooingleServiceUnitTest : AnnotationSpec() {
     @Test
     fun `존재하지 않는 guestId를 전달하면 뒹글을 등록할 때 예외가 발생한다`() {
         // given
-        val dooingleAdditionRequest = AddDooingleRequest(guest.id!!, "새 뒹글 내용")
+//        val dooingleAdditionRequest = AddDooingleRequest(guest.id!!, "새 뒹글 내용")
 
         every { mockSocialUserRepository.findByIdOrNull(guest.id!!) } returns null // 존재하지 않는 guestId 가정
 
         // when
-        val result = kotlin.runCatching { dooingleService.addDooingle(owner.id!!, dooingleAdditionRequest) }
+//        val result = kotlin.runCatching { dooingleService.addDooingle(owner.id!!, dooingleAdditionRequest) }
 
         // then // TODO 예외 처리 공통화 이후 더 자세하게 예외 점검할 것
-        result.shouldNotBeSuccess()
-        shouldThrow<Exception> { result.getOrThrow() }
+//        result.shouldNotBeSuccess()
+//        shouldThrow<Exception> { result.getOrThrow() }
     }
 
     @Test
     fun `존재하지 않는 ownerId를 전달하면 뒹글을 등록할 때 예외가 발생한다`() {
         // given
-        val dooingleAdditionRequest = AddDooingleRequest(guest.id!!, "새 뒹글 내용")
+//        val dooingleAdditionRequest = AddDooingleRequest(guest.id!!, "새 뒹글 내용")
 
         every { mockSocialUserRepository.findByIdOrNull(guest.id!!) } returns guest
         every { mockSocialUserRepository.findByIdOrNull(owner.id!!) } returns null // 존재하지 않는 ownerId 가정
 
         // when
-        val result = kotlin.runCatching { dooingleService.addDooingle(owner.id!!, dooingleAdditionRequest) }
+//        val result = kotlin.runCatching { dooingleService.addDooingle(owner.id!!, dooingleAdditionRequest) }
 
         // then // TODO 예외 처리 공통화 이후 더 자세하게 예외 점검할 것
-        result.shouldNotBeSuccess()
-        shouldThrow<Exception> { result.getOrThrow() }
+//        result.shouldNotBeSuccess()
+//        shouldThrow<Exception> { result.getOrThrow() }
     }
 
     /*
@@ -139,11 +142,11 @@ class DooingleServiceUnitTest : AnnotationSpec() {
         every { mockSocialUserRepository.findByIdOrNull(owner.id!!) } returns null // 존재하지 않는 ownerId 가정
 
         // when
-        val result = kotlin.runCatching { dooingleService.getPage(owner.id!!, guest.id!!, null) }
+//        val result = kotlin.runCatching { dooingleService.getPage(owner.id!!, guest.id!!, null) }
 
         // then // TODO 예외 처리 공통화 이후 더 자세하게 예외 점검할 것
-        result.shouldNotBeSuccess()
-        shouldThrow<Exception> { result.getOrThrow() }
+//        result.shouldNotBeSuccess()
+//        shouldThrow<Exception> { result.getOrThrow() }
     }
 
     @Test
@@ -152,11 +155,11 @@ class DooingleServiceUnitTest : AnnotationSpec() {
         every { mockSocialUserRepository.findByIdOrNull(owner.id!!) } returns null // 존재하지 않는 ownerId 가정
 
         // when
-        val result = kotlin.runCatching { dooingleService.getPage(owner.id!!, guest.id!!, DooingleService.USER_FEED_PAGE_SIZE.toLong()) }
+//        val result = kotlin.runCatching { dooingleService.getPage(owner.id!!, guest.id!!, DooingleService.USER_FEED_PAGE_SIZE.toLong()) }
 
         // then // TODO 예외 처리 공통화 이후 더 자세하게 예외 점검할 것
-        result.shouldNotBeSuccess()
-        shouldThrow<Exception> { result.getOrThrow() }
+//        result.shouldNotBeSuccess()
+//        shouldThrow<Exception> { result.getOrThrow() }
     }
 
     @Test
@@ -167,7 +170,7 @@ class DooingleServiceUnitTest : AnnotationSpec() {
         every { mockDooingleRepository.getDooinglesBySlice(cursor, pageRequest) } returns theLatestSliceOfDooingleResponseList
 
         // when
-        val result = dooingleService.getDooingleFeeds(cursor, PageRequest.ofSize(DooingleFeedController.PAGE_SIZE))
+        val result = dooingleService.getDooingleFeed(cursor, PageRequest.ofSize(DooingleFeedController.PAGE_SIZE))
 
         // then
         /*result.size shouldBe DooingleFeedController.PAGE_SIZE // 실제 가져오는 크기가 PAGE_SIZE보다 작은 경우 문제*/
@@ -182,7 +185,7 @@ class DooingleServiceUnitTest : AnnotationSpec() {
         every { mockDooingleRepository.getDooinglesBySlice(cursor, pageRequest) } returns theNextOfLatestSliceOfDooingleResponseList
 
         // when
-        val result = dooingleService.getDooingleFeeds(cursor, PageRequest.ofSize(DooingleFeedController.PAGE_SIZE))
+        val result = dooingleService.getDooingleFeed(cursor, PageRequest.ofSize(DooingleFeedController.PAGE_SIZE))
 
         // then
         /*result.size shouldBe DooingleFeedController.PAGE_SIZE // 실제 가져오는 크기가 PAGE_SIZE보다 작은 경우 문제*/


### PR DESCRIPTION
## 연관 이슈
- closes #56 

## 해당 작업을 한 동기/이유는 무엇인가요?
- 팔로우하는 사람의 뒹글 목록을 볼 수 있는 피드 기능을 구현했습니다.
- 기존 피드 기능의 QueryDslRepository 메서드에서 중복되는 부분이 많아 제네릭을 사용해 리팩토링했습니다.

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] 팔로우하는 유저의 뒹글 목록(피드) 조회 기능 구현
- [x] 기존 피드 메서드 약간의 수정
    - Controller와 Service에서 메서드명 Feeds -> Feed 로 수정했습니다! 구글링해봤는데 피드를 복수형으로 쓰지는 않더라고요..!
    - Service에서 기존 피드 메서드, 팔로우 피드 메서드 위치 수정했습니다! 안 쓰는 메서드들 위로 올렸어요! (안 쓰는 메서드들도 나중에 지우면 좋을 듯합니다 😊)
- [x] DooingleQueryDslRepositoryImpl 리팩토링
    - SliceImpl로 변환하는 부분이 중복되어서 메서드로 추가했습니다! 제네릭을 사용해서 한 메서드로 통일했습니다!
    - hasNext 판단하는 메서드가 다른 타입으로 두 개 있어서 제네릭을 사용해 통일했습니다! -> 혹시 제네릭 사용 시 문제점이 있을까요?! 문제가 있다면 타입 명시해서 오버로딩하는 방식으로 다시 바꾸겠습니다!!