### PR TITLE
refactor: 뒹글 피드 API 응답 DTO 추가 및 API 처리 로직 수정

### DIFF
--- a/src/main/kotlin/com/dooingle/domain/dooingle/controller/DooingleFeedController.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/controller/DooingleFeedController.kt
@@ -1,6 +1,6 @@
 package com.dooingle.domain.dooingle.controller
 
-import com.dooingle.domain.dooingle.dto.DooingleResponse
+import com.dooingle.domain.dooingle.dto.DooingleFeedResponse
 import com.dooingle.domain.dooingle.service.DooingleService
 import com.dooingle.global.security.UserPrincipal
 import org.springframework.data.domain.PageRequest
@@ -18,7 +18,7 @@ class DooingleFeedController(
 ) {
 
     @GetMapping
-    fun getDooingleFeed(cursor: Long?): ResponseEntity<Slice<DooingleResponse>> {
+    fun getDooingleFeed(cursor: Long?): ResponseEntity<Slice<DooingleFeedResponse>> {
         val pageRequest = PageRequest.ofSize(PAGE_SIZE)
         return ResponseEntity.ok(dooingleService.getDooingleFeed(cursor, pageRequest))
     }
@@ -27,7 +27,7 @@ class DooingleFeedController(
     fun getDooingleFeedOfFollowing(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         cursor: Long?
-    ): ResponseEntity<Slice<DooingleResponse>> {
+    ): ResponseEntity<Slice<DooingleFeedResponse>> {
         val pageRequest = PageRequest.ofSize(PAGE_SIZE)
         return ResponseEntity.ok(dooingleService.getDooingleFeedOfFollowing(userPrincipal.id, cursor, pageRequest))
     }

--- a/src/main/kotlin/com/dooingle/domain/dooingle/dto/DooingleFeedResponse.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/dto/DooingleFeedResponse.kt
@@ -1,0 +1,12 @@
+package com.dooingle.domain.dooingle.dto
+
+import java.time.ZonedDateTime
+
+data class DooingleFeedResponse(
+    val ownerName: String,
+    val ownerId: Long,
+    val dooingleId: Long,
+    val content: String,
+    val hasCatch: Boolean,
+    val createdAt: ZonedDateTime,
+)

--- a/src/main/kotlin/com/dooingle/domain/dooingle/repository/DooingleQueryDslRepository.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/repository/DooingleQueryDslRepository.kt
@@ -1,16 +1,16 @@
 package com.dooingle.domain.dooingle.repository
 
 import com.dooingle.domain.dooingle.dto.DooingleAndCatchResponse
-import com.dooingle.domain.dooingle.dto.DooingleResponse
+import com.dooingle.domain.dooingle.dto.DooingleFeedResponse
 import com.dooingle.domain.user.model.SocialUser
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
 interface DooingleQueryDslRepository {
 
-    fun getDooinglesBySlice(cursor: Long?, pageable: Pageable): Slice<DooingleResponse>
+    fun getDooinglesBySlice(cursor: Long?, pageable: Pageable): Slice<DooingleFeedResponse>
 
-    fun getDooinglesFollowingBySlice(userId: Long, cursor: Long?, pageable: Pageable): Slice<DooingleResponse>
+    fun getDooinglesFollowingBySlice(userId: Long, cursor: Long?, pageable: Pageable): Slice<DooingleFeedResponse>
 
     fun getPersonalPageBySlice(owner: SocialUser, cursor: Long?, pageable: Pageable): Slice<DooingleAndCatchResponse>
 

--- a/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
@@ -4,6 +4,7 @@ import com.dooingle.domain.catchdomain.model.Catch
 import com.dooingle.domain.catchdomain.repository.CatchRepository
 import com.dooingle.domain.dooingle.dto.AddDooingleRequest
 import com.dooingle.domain.dooingle.dto.DooingleAndCatchResponse
+import com.dooingle.domain.dooingle.dto.DooingleFeedResponse
 import com.dooingle.domain.dooingle.dto.DooingleResponse
 import com.dooingle.domain.dooingle.model.Dooingle
 import com.dooingle.domain.dooingle.repository.DooingleRepository
@@ -66,11 +67,11 @@ class DooingleService(
         return dooingleRepository.getPersonalPageBySlice(owner, cursor, pageRequest)
     }
 
-    fun getDooingleFeed(cursor: Long?, pageRequest: PageRequest): Slice<DooingleResponse> {
+    fun getDooingleFeed(cursor: Long?, pageRequest: PageRequest): Slice<DooingleFeedResponse> {
         return dooingleRepository.getDooinglesBySlice(cursor, pageRequest)
     }
 
-    fun getDooingleFeedOfFollowing(userId: Long, cursor: Long?, pageRequest: PageRequest): Slice<DooingleResponse> {
+    fun getDooingleFeedOfFollowing(userId: Long, cursor: Long?, pageRequest: PageRequest): Slice<DooingleFeedResponse> {
         return dooingleRepository.getDooinglesFollowingBySlice(userId, cursor, pageRequest)
     }
 

--- a/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceUnitTest.kt
+++ b/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceUnitTest.kt
@@ -3,6 +3,7 @@ package com.dooingle.domain.dooingle.service
 import com.dooingle.domain.catchdomain.repository.CatchRepository
 import com.dooingle.domain.dooingle.controller.DooingleFeedController
 import com.dooingle.domain.dooingle.dto.AddDooingleRequest
+import com.dooingle.domain.dooingle.dto.DooingleFeedResponse
 import com.dooingle.domain.dooingle.dto.DooingleResponse
 import com.dooingle.domain.dooingle.repository.DooingleRepository
 import com.dooingle.domain.dooinglecount.repository.DooingleCountRepository
@@ -44,21 +45,21 @@ class DooingleServiceUnitTest : AnnotationSpec() {
     lateinit var owner: SocialUser
     lateinit var guest: SocialUser
 //    lateinit var dooingleAndCatchResponseSlice: Slice<DooingleAndCatchResponse>
-    lateinit var dooingleResponseList: List<DooingleResponse>
-    lateinit var theLatestSliceOfDooingleResponseList: Slice<DooingleResponse>
-    lateinit var theNextOfLatestSliceOfDooingleResponseList: Slice<DooingleResponse>
+    lateinit var dooingleFeedResponseList: List<DooingleFeedResponse>
+    lateinit var theLatestSliceOfDooingleFeedResponseList: Slice<DooingleFeedResponse>
+    lateinit var theNextOfLatestSliceOfDooingleResponseList: Slice<DooingleFeedResponse>
 
     @BeforeAll
     fun prepareFixture() {
         owner = getFixtureOfOwner()
         guest = getFixtureOfGuest()
         // dooingleAndCatchResponseSlice = SliceImpl(getFixtureOfDooingleAndCatchResponseList())
-        dooingleResponseList = getFixtureOfDooingleResponseList()
-        theLatestSliceOfDooingleResponseList = SliceImpl(dooingleResponseList.subList(0, DooingleFeedController.PAGE_SIZE))
+        dooingleFeedResponseList = getFixtureOfDooingleResponseList()
+        theLatestSliceOfDooingleFeedResponseList = SliceImpl(dooingleFeedResponseList.subList(0, DooingleFeedController.PAGE_SIZE))
         theNextOfLatestSliceOfDooingleResponseList = SliceImpl(
-            dooingleResponseList.subList(
+            dooingleFeedResponseList.subList(
                 DooingleFeedController.PAGE_SIZE,
-                min(DooingleFeedController.PAGE_SIZE + DooingleFeedController.PAGE_SIZE, dooingleResponseList.size),
+                min(DooingleFeedController.PAGE_SIZE + DooingleFeedController.PAGE_SIZE, dooingleFeedResponseList.size),
             )
         )
     }
@@ -167,14 +168,14 @@ class DooingleServiceUnitTest : AnnotationSpec() {
         // given
         val cursor: Long? = null // 최신 뒹글 피드 조건
         val pageRequest = PageRequest.ofSize(DooingleFeedController.PAGE_SIZE)
-        every { mockDooingleRepository.getDooinglesBySlice(cursor, pageRequest) } returns theLatestSliceOfDooingleResponseList
+        every { mockDooingleRepository.getDooinglesBySlice(cursor, pageRequest) } returns theLatestSliceOfDooingleFeedResponseList
 
         // when
         val result = dooingleService.getDooingleFeed(cursor, PageRequest.ofSize(DooingleFeedController.PAGE_SIZE))
 
         // then
         /*result.size shouldBe DooingleFeedController.PAGE_SIZE // 실제 가져오는 크기가 PAGE_SIZE보다 작은 경우 문제*/
-        result.content.first().dooingleId shouldBe theLatestSliceOfDooingleResponseList.first().dooingleId
+        result.content.first().dooingleId shouldBe theLatestSliceOfDooingleFeedResponseList.first().dooingleId
     }
 
     @Test
@@ -240,28 +241,28 @@ class DooingleServiceUnitTest : AnnotationSpec() {
 //        DooingleAndCatchResponse(owner.nickname, 15, "뒹글 내용 1", Catch("캐치 내용", Dooingle(guest, owner, null, "뒹글 내용"),null), ZonedDateTime.now()),
 //    ).sortedBy { it.dooingleId }
 
-    private fun getFixtureOfDooingleResponseList() = listOf<DooingleResponse>(
-        DooingleResponse(owner.nickname, 1, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 2, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 3, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 4, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 5, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 6, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 7, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 8, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 9, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 10, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 11, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 12, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 13, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 14, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 15, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 16, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 17, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 18, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 19, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 20, "뒹글 내용", ZonedDateTime.now()),
-        DooingleResponse(owner.nickname, 21, "뒹글 내용", ZonedDateTime.now()),
+    private fun getFixtureOfDooingleResponseList(): List<DooingleFeedResponse> = listOf<DooingleFeedResponse>(
+        DooingleFeedResponse(owner.nickname, 1, 1, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 2, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 3, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 4, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 5, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 6, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 7, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 8, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 9, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 10, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 11, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 12, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 13, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 14, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 15, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 16, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 17, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 18, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 19, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 20, "뒹글 내용", false, ZonedDateTime.now()),
+        DooingleFeedResponse(owner.nickname, 1, 21, "뒹글 내용", false, ZonedDateTime.now()),
     ).sortedBy { it.dooingleId }
 
     companion object {


### PR DESCRIPTION
## 연관 이슈
- closes #83 

## 해당 작업을 한 동기/이유는 무엇인가요?
- 현재 뒹글 피드 API 응답이 뒹글 피드 화면에서 필요한 데이터인 owner의 id와 catch 존재 여부를 갖고 있지 않아 이를 수정할 필요가 있었습니다.
- 그런데 DooingleResponse는 다른 API에서도 사용하고 있고, 그 API들에서는 owner id나 catch가 꼭 필요하지 않은 것으로 판단했습니다.
  - 따라서 뒹글 피드 관련 API에서만 사용할 DooingleFeedResponse DTO를 새로 작성하였습니다.

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] 응답 DTO DooingleFeedResponse 추가
  - (DooingleResponse DTO와 비교) 뒹글 owner의 id 및 catch 존재 여부 데이터 추가
  - 사유: 뒹글 클릭 시 owner의 뒹글 페이지로 연결하게 하기 위함, 답변 존재 여부를 사용자가 확인하게 하기 위함
- [x] 응답 DTO 추가에 따른 API 처리 로직 수정
- [x] API 처리 로직 수정에 따라 서비스 레이어 테스트 코드 수정
  - 사유: service layer 메서드의 반환 타입이 달라지므로 이를 테스트하는 테스트 메서드에서도 타입을 바꿔야 함
