### PR TITLE
Test: 팔로우 피드 조회 통합 테스트

### DIFF
--- a/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
@@ -72,6 +72,9 @@ class DooingleService(
     }
 
     fun getDooingleFeedOfFollowing(userId: Long, cursor: Long?, pageRequest: PageRequest): Slice<DooingleFeedResponse> {
+        val user = socialUserRepository.findByIdOrNull(userId)
+            ?: throw ModelNotFoundException(modelName = "Social User", modelId = userId)
+
         return dooingleRepository.getDooinglesFollowingBySlice(userId, cursor, pageRequest)
     }
 

--- a/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceDBTest.kt
+++ b/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceDBTest.kt
@@ -63,7 +63,7 @@ class DooingleServiceDBTest(
     }
 
     @Test
-    fun `특정 회원이 다른 회원들을 팔로우하는 경우 팔로우 피드를 조회하면 팔로우하는 유저에게 굴러온 뒹글 목록을 최신 글부터 조회한다`() {
+    fun `특정 유저가 다른 유저들을 팔로우하는 경우 팔로우 피드를 조회하면 팔로우하는 유저에게 굴러온 뒹글 목록을 최신 글부터 조회한다`() {
         // GIVEN
         socialUserRepository.saveAll(userList)
         followRepository.saveAll(followingList)
@@ -88,7 +88,7 @@ class DooingleServiceDBTest(
     }
 
     @Test
-    fun `특정 회원이 다른 회원들을 팔로우하는 경우 커서와 함께 팔로우 피드를 조회하면 팔로우하는 유저에게 굴러온 뒹글 목록을 커서 이전 글부터 조회한다`() {
+    fun `특정 유저가 다른 유저들을 팔로우하는 경우 커서와 함께 팔로우 피드를 조회하면 팔로우하는 유저에게 굴러온 뒹글 목록을 커서 이전 글부터 조회한다`() {
         // GIVEN
         socialUserRepository.saveAll(userList)
         followRepository.saveAll(followingList)
@@ -110,6 +110,22 @@ class DooingleServiceDBTest(
         result.zip(dooinglesFollowingBeforeCursorSortedList) { response, entity -> response.dooingleId shouldBe entity.id }
 
         result.content.size shouldBe dooinglesFollowingBeforeCursorSortedList.size
+        result.hasNext() shouldBe false
+    }
+
+    @Test
+    fun `특정 유저가 다른 유저를 팔로우하지 않는 경우 팔로우 피드를 조회하면 0건의 결과가 조회된다`() {
+        // GIVEN
+        socialUserRepository.saveAll(userList)
+        dooingleRepository.saveAll(dooingleList)
+
+        val userId: Long = userA.id!!
+
+        // WHEN
+        val result = dooingleService.getDooingleFeedOfFollowing(userId, null, DEFAULT_PAGE_REQUEST)
+
+        // THEN
+        result.content.size shouldBe 0
         result.hasNext() shouldBe false
     }
 

--- a/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceDBTest.kt
+++ b/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceDBTest.kt
@@ -1,0 +1,196 @@
+package com.dooingle.domain.dooingle.service
+
+import com.dooingle.domain.catchdomain.repository.CatchRepository
+import com.dooingle.domain.dooingle.controller.DooingleFeedController
+import com.dooingle.domain.dooingle.model.Dooingle
+import com.dooingle.domain.dooingle.repository.DooingleRepository
+import com.dooingle.domain.dooinglecount.repository.DooingleCountRepository
+import com.dooingle.domain.follow.model.Follow
+import com.dooingle.domain.follow.repository.FollowRepository
+import com.dooingle.domain.notification.service.NotificationService
+import com.dooingle.domain.user.model.SocialUser
+import com.dooingle.domain.user.repository.SocialUserRepository
+import com.dooingle.global.exception.custom.ModelNotFoundException
+import com.dooingle.global.oauth2.provider.OAuth2Provider
+import com.dooingle.global.property.DooinglersProperties
+import com.dooingle.global.querydsl.QueryDslConfig
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.longs.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestConstructor
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(value = [QueryDslConfig::class])
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@ActiveProfiles("test")
+class DooingleServiceDBTest(
+    private val dooingleRepository: DooingleRepository,
+    private val socialUserRepository: SocialUserRepository,
+    private val catchRepository: CatchRepository,
+    private val dooingleCountRepository: DooingleCountRepository,
+    private val followRepository: FollowRepository
+) {
+
+    @MockBean
+    lateinit var dooinglersProperties: DooinglersProperties
+
+    private val mockNotificationService = mockk<NotificationService>()
+
+    private val dooingleService = DooingleService(
+        dooingleRepository,
+        socialUserRepository,
+        catchRepository,
+        dooingleCountRepository,
+        mockNotificationService
+    )
+
+    @BeforeEach
+    fun clearData() {
+        dooingleRepository.deleteAll()
+        followRepository.deleteAll()
+        socialUserRepository.deleteAll()
+    }
+
+    @Test
+    fun `팔로우 피드 조회 시 커서가 전달되지 않는다면 팔로우하는 유저에게 굴러온 뒹글 목록을 최신 글부터 조회한다`() {
+        // GIVEN
+        socialUserRepository.saveAll(userList)
+        followRepository.saveAll(followingList)
+        dooingleRepository.saveAll(dooingleList)
+
+        val userId: Long = userA.id!!
+
+        // WHEN
+        val result = dooingleService.getDooingleFeedOfFollowing(userId, null, DEFAULT_PAGE_REQUEST)
+
+        // THEN
+        result.content.forEach { it.ownerId shouldBeIn listOf(userB.id, userC.id) }
+
+        val dooinglesFollowing = dooingleRepository.findAll()
+            .filter { it.owner.id == userB.id || it.owner.id == userC.id }
+            .sortedByDescending { it.id }
+        result.content[0].dooingleId shouldBe dooinglesFollowing[0].id
+
+        for (i in 0 until result.content.size - 1) {
+            result.content[i].dooingleId shouldBeGreaterThan result.content[i + 1].dooingleId
+        }
+
+        result.content.size shouldBe DooingleFeedController.PAGE_SIZE
+        result.hasNext() shouldBe true
+    }
+
+    @Test
+    fun `팔로우 피드 조회 시 커서가 전달되면 팔로우하는 유저에게 굴러온 뒹글 목록을 커서 이전 글부터 조회한다`() {
+        // GIVEN
+        socialUserRepository.saveAll(userList)
+        followRepository.saveAll(followingList)
+        dooingleRepository.saveAll(dooingleList)
+
+        val userId: Long = userA.id!!
+        val cursor: Long = 6
+
+        // WHEN
+        val result = dooingleService.getDooingleFeedOfFollowing(userId, cursor, DEFAULT_PAGE_REQUEST)
+
+        result.content.forEach { it.ownerId shouldBeIn listOf(userB.id, userC.id) }
+
+        val dooinglesFollowingBeforeCursor = dooingleRepository.findAll()
+            .filter { it.owner.id == userB.id || it.owner.id == userC.id }
+            .filter { it.id!! < cursor }
+            .sortedByDescending { it.id }
+        result.content[0].dooingleId shouldBe dooinglesFollowingBeforeCursor[0].id
+
+        for (i in 0 until result.content.size - 1) {
+            result.content[i].dooingleId shouldBeGreaterThan result.content[i + 1].dooingleId
+        }
+
+        result.content.size shouldBe dooinglesFollowingBeforeCursor.size
+        result.hasNext() shouldBe false
+    }
+
+    @Test
+    fun `팔로우 피드 조회 시 전달된 user id의 유저가 존재하지 않는다면 예외가 발생한다`() {
+        // GIVEN
+        socialUserRepository.saveAll(userList)
+        val userId: Long = 100
+
+        // WHEN & THEN
+        shouldThrow<ModelNotFoundException> {
+            dooingleService.getDooingleFeedOfFollowing(userId, null, DEFAULT_PAGE_REQUEST)
+        }
+
+        socialUserRepository.findByIdOrNull(userId) shouldBe null
+    }
+
+    private val userA = SocialUser(nickname = "A", provider = OAuth2Provider.KAKAO, providerId = "1")
+    private val userB = SocialUser(nickname = "B", provider = OAuth2Provider.KAKAO, providerId = "2")
+    private val userC = SocialUser(nickname = "C", provider = OAuth2Provider.KAKAO, providerId = "3")
+    private val userD = SocialUser(nickname = "D", provider = OAuth2Provider.KAKAO, providerId = "4")
+    private val userList = listOf(userA, userB, userC, userD)
+
+    private val followingList = listOf(
+        Follow(fromUser = userA, toUser = userB),
+        Follow(fromUser = userA, toUser = userC)
+    )
+
+    private val dooingleList = listOf(
+        Dooingle(owner = userA, guest = userB, content = "A에게 질문", catch = null),
+        Dooingle(owner = userB, guest = userC, content = "B에게 질문", catch = null),
+        Dooingle(owner = userC, guest = userD, content = "C에게 질문", catch = null),
+        Dooingle(owner = userD, guest = userA, content = "D에게 질문", catch = null),
+        Dooingle(owner = userA, guest = userB, content = "A에게 질문", catch = null),
+        Dooingle(owner = userB, guest = userC, content = "B에게 질문", catch = null),
+        Dooingle(owner = userC, guest = userD, content = "C에게 질문", catch = null),
+        Dooingle(owner = userD, guest = userA, content = "D에게 질문", catch = null),
+        Dooingle(owner = userA, guest = userB, content = "A에게 질문", catch = null),
+        Dooingle(owner = userB, guest = userC, content = "B에게 질문", catch = null),
+        Dooingle(owner = userC, guest = userD, content = "C에게 질문", catch = null),
+        Dooingle(owner = userD, guest = userA, content = "D에게 질문", catch = null),
+        Dooingle(owner = userA, guest = userB, content = "A에게 질문", catch = null),
+        Dooingle(owner = userB, guest = userC, content = "B에게 질문", catch = null),
+        Dooingle(owner = userC, guest = userD, content = "C에게 질문", catch = null),
+        Dooingle(owner = userD, guest = userA, content = "D에게 질문", catch = null),
+        Dooingle(owner = userA, guest = userB, content = "A에게 질문", catch = null),
+        Dooingle(owner = userB, guest = userC, content = "B에게 질문", catch = null),
+        Dooingle(owner = userC, guest = userD, content = "C에게 질문", catch = null),
+        Dooingle(owner = userD, guest = userA, content = "D에게 질문", catch = null),
+        Dooingle(owner = userA, guest = userB, content = "A에게 질문", catch = null),
+        Dooingle(owner = userB, guest = userC, content = "B에게 질문", catch = null),
+        Dooingle(owner = userC, guest = userD, content = "C에게 질문", catch = null),
+        Dooingle(owner = userD, guest = userA, content = "D에게 질문", catch = null),
+        Dooingle(owner = userA, guest = userB, content = "A에게 질문", catch = null),
+        Dooingle(owner = userB, guest = userC, content = "B에게 질문", catch = null),
+        Dooingle(owner = userC, guest = userD, content = "C에게 질문", catch = null),
+        Dooingle(owner = userD, guest = userA, content = "D에게 질문", catch = null),
+        Dooingle(owner = userA, guest = userB, content = "A에게 질문", catch = null),
+        Dooingle(owner = userB, guest = userC, content = "B에게 질문", catch = null),
+        Dooingle(owner = userC, guest = userD, content = "C에게 질문", catch = null),
+        Dooingle(owner = userD, guest = userA, content = "D에게 질문", catch = null),
+        Dooingle(owner = userA, guest = userB, content = "A에게 질문", catch = null),
+        Dooingle(owner = userB, guest = userC, content = "B에게 질문", catch = null),
+        Dooingle(owner = userC, guest = userD, content = "C에게 질문", catch = null),
+        Dooingle(owner = userD, guest = userA, content = "D에게 질문", catch = null),
+        Dooingle(owner = userA, guest = userB, content = "A에게 질문", catch = null),
+        Dooingle(owner = userB, guest = userC, content = "B에게 질문", catch = null),
+        Dooingle(owner = userC, guest = userD, content = "C에게 질문", catch = null),
+        Dooingle(owner = userD, guest = userA, content = "D에게 질문", catch = null),
+        Dooingle(owner = userA, guest = userB, content = "A에게 질문", catch = null),
+        Dooingle(owner = userB, guest = userC, content = "B에게 질문", catch = null),
+        Dooingle(owner = userC, guest = userD, content = "C에게 질문", catch = null),
+        Dooingle(owner = userD, guest = userA, content = "D에게 질문", catch = null),
+    )
+
+    private val DEFAULT_PAGE_REQUEST = PageRequest.ofSize(DooingleFeedController.PAGE_SIZE)
+}

--- a/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceUnitTest.kt
+++ b/src/test/kotlin/com/dooingle/domain/dooingle/service/DooingleServiceUnitTest.kt
@@ -193,21 +193,6 @@ class DooingleServiceUnitTest : AnnotationSpec() {
         result.content.first().dooingleId shouldBe theNextOfLatestSliceOfDooingleResponseList.first().dooingleId
     }
 
-    @Test
-    fun `팔로우 피드를 조회하면 팔로우하는 사람의 뒹글 목록만 조회한다`() {
-        // 팔로우하지 않는 사람의 뒹글은 조회되지 않아야 함
-    }
-
-    @Test
-    fun `팔로우 피드 조회 시 커서가 전달되지 않는다면 최신 글부터 조회한다`() {
-
-    }
-
-    @Test
-    fun `팔로우 피드 조회 시 커서가 전달되면 커서 이전 글부터 조회한다`() {
-
-    }
-
     private fun getFixtureOfOwner() = SocialUser(
         id = ownerId,
         provider = ownerOAuthProvider,


### PR DESCRIPTION
## 연관 이슈
- closes #99 

## 해당 작업을 한 동기/이유는 무엇인가요?
- 팔로우하는 유저의 페이지에 등록된 뒹글만 조회하는 기능을 테스트합니다.

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] 팔로우 피드 조회 시 인자로 전달된 userId의 유저가 존재하지 않으면 예외 발생 로직 추가
  - DooingleService 메서드에서 ModelNotFoundException 발생시킴
- [x] 팔로우 피드 조회 기능 통합 테스트
    - 특정 유저가 다른 유저들을 팔로우하는 경우 팔로우 피드를 조회하면 팔로우하는 유저에게 굴러온 뒹글 목록을 최신 글부터 조회한다
    - 특정 유저가 다른 유저들을 팔로우하는 경우 커서와 함께 팔로우 피드를 조회하면 팔로우하는 유저에게 굴러온 뒹글 목록을 커서 이전 글부터 조회한다
    - 특정 유저가 다른 유저를 팔로우하지 않는 경우 팔로우 피드를 조회하면 0건의 결과가 조회된다
    - 존재하지 않는 유저의 팔로우 피드를 조회하면 예외가 발생한다
    
## 참고사항
- 일단 NotificationService는 지금 테스트코드에서 쓰지 않아서 mocking해서 주입했습니다. 다른 테스트코드 작성 시에 필요하다면 변경하십쇼..!!
- BehaviorSpec으로 하더라도 매번 DB에 저장한 뒤에 테스트하는 게 맞는 듯 싶어 바꾸지 않았습니당..ㅎ