### PR TITLE
refactor: CORS 설정 리팩토링 및 프론트엔드 axios 설정

### DIFF
--- a/dooingle-front/src/pages/Feed.jsx
+++ b/dooingle-front/src/pages/Feed.jsx
@@ -1,13 +1,13 @@
-import { Link } from "react-router-dom";
+import {Link} from "react-router-dom";
 import Header from "../components/Header.jsx";
 import Dooingle from "../components/Dooingle.jsx";
 import ProfileImageFrame from "../components/ProfileImageFrame.jsx";
 import Navigation from "../components/Navigation.jsx";
 import DooinglerListAside from "../components/DooinglerListAside.jsx";
 import {useEffect, useState} from "react";
-import { EventSourcePolyfill } from 'event-source-polyfill';
+import {EventSourcePolyfill} from 'event-source-polyfill';
 import axios from "axios";
-import { BACKEND_SERVER_ORIGIN } from "../env.js"
+import {BACKEND_SERVER_ORIGIN} from "../env.js"
 
 const sliceInitialState = {
   // initial state를 안 정해주면 에러 발생해서 렌더링이 안 됨
@@ -35,7 +35,7 @@ export default function FeedPage() {
 
   useEffect(() => {
     async function fetchDooingleSlice() {
-      const response = await axios.get(`${BACKEND_SERVER_ORIGIN}/api/dooingles`);
+      const response = await axios.get(`${BACKEND_SERVER_ORIGIN}/api/dooingles`, {withCredentials: true});
       return response.data;
     }
 

--- a/src/main/kotlin/com/dooingle/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/dooingle/global/security/SecurityConfig.kt
@@ -1,6 +1,7 @@
 package com.dooingle.global.security
 
 import com.dooingle.global.jwt.JwtAuthenticationFilter
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
@@ -10,6 +11,9 @@ import org.springframework.security.web.AuthenticationEntryPoint
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.access.AccessDeniedHandler
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 @EnableWebSecurity
@@ -17,7 +21,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 class SecurityConfig(
     private val jwtAuthenticationFilter: JwtAuthenticationFilter,
     private val authenticationEntrypoint: AuthenticationEntryPoint,
-    private val accessDeniedHandler: AccessDeniedHandler
+    private val accessDeniedHandler: AccessDeniedHandler,
+    @Value("\${frontend.domain}") private val frontendOrigin: String, // profile에 따라 허용되는 origin 달라지게 함
 ) {
 
     @Bean
@@ -26,13 +31,16 @@ class SecurityConfig(
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
             .csrf { it.disable() }
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .headers { it.frameOptions { frameOptionsConfig -> frameOptionsConfig.sameOrigin() } }
             .authorizeHttpRequests {
-                it
-//                    .requestMatchers(
-//                        "/api/**"
-//                    ).authenticated()
-                    .anyRequest().permitAll()
+                it.requestMatchers(
+                    "/api/**",
+                ).authenticated()
+                    .requestMatchers(
+                        "/oauth2/login/**", "/oauth2/callback/**", "/swagger-ui/**", "/v3/api-docs/**", "/h2-console/**",
+                ).permitAll() // 로그인, 콜백 리다이렉트 url은 인증 불필요
+            // TODO: "/swagger-ui/**", "/v3/api-docs/**", "/h2-console/**"는 개발 환경에서만 인증 불필요하게 만들기
             }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .exceptionHandling {
@@ -40,5 +48,17 @@ class SecurityConfig(
                 it.accessDeniedHandler(accessDeniedHandler)
             }
             .build()
+    }
+
+    private fun corsConfigurationSource(): CorsConfigurationSource {
+        val configuration = CorsConfiguration()
+            .also { it.allowCredentials = true }
+            .also { it.allowedOrigins = listOf(frontendOrigin) }
+            .also { it.allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD", "TRACE") }
+            // .also { it.allowedHeaders = listOf("*") }.also { it.exposedHeaders = listOf("*") }
+            // 현 상태에서는 오류 발생하지 않아 주석 처리, 최소한만 허용함
+
+        return UrlBasedCorsConfigurationSource()
+            .also { it.registerCorsConfiguration("/**", configuration) }
     }
 }

--- a/src/main/kotlin/com/dooingle/global/web/WebConfig.kt
+++ b/src/main/kotlin/com/dooingle/global/web/WebConfig.kt
@@ -3,8 +3,6 @@ package com.dooingle.global.web
 import com.dooingle.global.oauth2.provider.OAuth2ProviderConverter
 import org.springframework.context.annotation.Configuration
 import org.springframework.format.FormatterRegistry
-import org.springframework.http.HttpHeaders
-import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
@@ -13,16 +11,4 @@ class WebConfig : WebMvcConfigurer {
     override fun addFormatters(registry: FormatterRegistry) {
         registry.addConverter(OAuth2ProviderConverter())
     }
-
-    override fun addCorsMappings(registry: CorsRegistry) {
-        registry.addMapping("/**")
-            .allowedMethods(*ALLOWED_METHOD_NAMES.split(",".toRegex()).dropLastWhile { it.isEmpty() }
-                .toTypedArray())
-            .exposedHeaders(HttpHeaders.LOCATION)
-    }
-
-    companion object {
-        const val ALLOWED_METHOD_NAMES: String = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH"
-    }
-
 }


### PR DESCRIPTION
## 연관 이슈
- closes #109 

## 해당 작업을 한 동기/이유는 무엇인가요?
- CORS 설정을 리팩토링하여 유지보수를 편하게 하고자 합니다.
  - 기존 WebConfig에 있던 CORS 설정을 SecurityConfig 쪽으로 이동
  - Access-Controll-Allow-Origin의 세밀한 설정

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] WebConfig에 있던 CORS 설정을 SecurityConfig 쪽으로 이동
- [x] 특정 origin에 대해서만 Access-Control-Allow-Origin 설정
  - 배포 환경별로 다른 origin에 대해 allow하도록 함

### 특이사항
- **백엔드 코드 변경 부분**은 SecurityConfig 파일과 WebConfig 파일입니다.
- dev가 아닌 frontend/dev로의 PR입니다.