### PR TITLE
refactor: userLink 사용 누락된 곳변경

### DIFF
--- a/src/main/kotlin/com/dooingle/domain/dooinglecount/repository/DooingleCountQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooinglecount/repository/DooingleCountQueryDslRepositoryImpl.kt
@@ -20,7 +20,7 @@ class DooingleCountQueryDslRepositoryImpl(
         return queryFactory.select(
             Projections.constructor(
                 DooinglerResponse::class.java,
-                socialUser.id,
+                socialUser.userLink,
                 socialUser.nickname
             )
         )


### PR DESCRIPTION
## 연관 이슈
- #118

## 해당 작업을 한 동기/이유는 무엇인가요?
- SocialUser 엔티티 userLink 추가 작업 후 userLink 사용 누락된 곳이 있어 API 호출 시 오류가 발생합니다.
  - DooingleCountQueryDslRepositoryImpl의 getHighCountDooinglers()에서 Projection 사용 시 오류 발생 중

### 특이사항
- dev로의 merge가 아니라 feat/frontend/personal-dooingle-page 브랜치로의 merge입니다.
- 백엔드 변경사항이 많아 사후 검토가 필요할 듯하여 별도로 PR을 올려 기록으로 남겨 둡니다.

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] DooingleCountQueryDslRepositoryImpl의 getHighCountDooinglers() 메서드에서 userId가 아닌 userLink를 사용하도록 변경
