### PR TITLE
feat: 프론트엔드 피드 페이지 알림 시 UI 표시, 뒹글의 답변 유무 표시, 링크 등 구현

### DIFF
--- a/dooingle-front/src/components/Dooingle.jsx
+++ b/dooingle-front/src/components/Dooingle.jsx
@@ -1,8 +1,19 @@
-export default function Dooingle({ownerName, content}) {
+import {Link} from "react-router-dom";
+
+export default function Dooingle({ownerName, ownerUserLink, dooingleId, content, hasCatch}) {
   return (
     <div className="flex flex-col p-[0.75rem] gap-[0.5rem]">
       <div className="text-[#456bf5] font-bold">
-        <p>익명의 뒹글러 → {ownerName?.toString()}</p>
+        <span>익명의 뒹글러 → </span>
+        <Link to={`/personal-dooingles/${ownerUserLink}`}>{ownerName}</Link>
+        {
+          hasCatch &&
+          <Link
+            to={`/personal-dooingles/${ownerUserLink}?lastDooingleId=${dooingleId + 1}`}
+            className="pl-[1rem] font-medium text-[#5f6368]">답변이 있는 뒹글입니다.
+          </Link>
+        }
+        {/* TODO dooingleId 넣어서 개인 페이지 해당 글로 바로 갈 수 있도록 만들기 */}
       </div>
       <div className="px-[1.25rem] py-[0.625rem] border-[0.03125rem] border-[#8692ff] rounded-[0.625rem]">
         <div className="text-[#5f6368]">

--- a/dooingle-front/src/main.jsx
+++ b/dooingle-front/src/main.jsx
@@ -4,7 +4,8 @@ import App from "./App.jsx"
 import "./index.css"
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+  // <React.StrictMode>
+  //   <App />
+  // </React.StrictMode>,
+  <App />
 )

--- a/dooingle-front/src/main.jsx
+++ b/dooingle-front/src/main.jsx
@@ -4,8 +4,7 @@ import App from "./App.jsx"
 import "./index.css"
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  // <React.StrictMode>
-  //   <App />
-  // </React.StrictMode>,
-  <App />
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
 )

--- a/dooingle-front/src/pages/Feed.jsx
+++ b/dooingle-front/src/pages/Feed.jsx
@@ -9,21 +9,6 @@ import {EventSourcePolyfill} from 'event-source-polyfill';
 import axios from "axios";
 import {BACKEND_SERVER_ORIGIN} from "../env.js"
 
-/*
-const sliceInitialState = {
-  // initial state를 안 정해주면 에러 발생해서 렌더링이 안 됨
-  size: 0,
-  content: [],
-  number: 0,
-  sort: {},
-  first: true,
-  last: true,
-  numberOfElements: 0,
-  pageable: {},
-  empty: true,
-}
- */
-
 async function fetchDooinglesFeed(lastDooingleId = null) {
   const queryParameter = lastDooingleId === null ? "" : `?cursor=${lastDooingleId}`
 
@@ -189,7 +174,10 @@ export default function FeedPage() {
               <Dooingle
                 key={dooingle.dooingleId}
                 ownerName={dooingle.ownerName}
+                ownerUserLink={dooingle.ownerUserLink}
+                dooingleId={dooingle.dooingleId}
                 content={dooingle.content}
+                hasCatch={dooingle.hasCatch}
               />
             ))}
           </div>

--- a/dooingle-front/src/pages/Feed.jsx
+++ b/dooingle-front/src/pages/Feed.jsx
@@ -58,7 +58,7 @@ async function fetchLoggedInUserLink() {
 export default function FeedPage() {
 
   const [sseNotification, setSseNotification] = useState(notificationInitialState);
-  const [feed, setFeed] = useState(null);
+  const [newFeedNotification, setNewFeedNotification] = useState(null);
   const [currentUserLink, setCurrentUserLink] = useState(undefined);
   const [dooingles, setDooingles] = useState([]);
   const [isEntireFeed, setIsEntireFeed] = useState(true) // TODO isEntireFeed state가 정말 필요한지는 더 고민해볼 것
@@ -68,7 +68,48 @@ export default function FeedPage() {
     fetchLoggedInUserLink().then(loggedInUserLink => {
       setCurrentUserLink(loggedInUserLink)
     })
+
+    const eventSource = new EventSourcePolyfill(`${BACKEND_SERVER_ORIGIN}/api/notifications/connect`,
+      {withCredentials: true}
+    );
+
+    addSseConnectionEventListenerToEventSource(eventSource)
+    addNewFeedNotificationEventListenerToEventSource(eventSource);
+    addPersonalNotificationEventListenerToEventSource(eventSource);
+
+    return () => {
+      eventSource.close(); // 컴포넌트 unmount할 때 eventSource 닫기
+    }
   }, []);
+
+  function addSseConnectionEventListenerToEventSource(eventSource) {
+    eventSource.addEventListener("connect", (event) => {
+      const { data: receivedConnectData } = event;
+      console.log("connect event data: ", receivedConnectData);
+    });
+  }
+
+  function addNewFeedNotificationEventListenerToEventSource(eventSource) {
+    eventSource.addEventListener("feed", event => {
+      const receivedFeed = JSON.parse(event.data);
+      setNewFeedNotification(receivedFeed); // 전달받는 데이터는 DooingleResponse 형식
+      // TODO : 전달받는 데이터로 뒹글 컴포넌트 만들어서 뒹글 목록 위에 추가
+    });
+  }
+
+  function addPersonalNotificationEventListenerToEventSource(eventSource) {
+    eventSource.addEventListener("notification", event => {
+      const receivedNotification = JSON.parse(event.data);
+
+      switch (receivedNotification.notificationType) {
+        case "DOOINGLE": receivedNotification.message = "새 뒹글이 굴러왔어요!"; break;
+        case "CATCH": receivedNotification.message = "내 뒹글에 캐치가 달렸어요!"; break;
+      }
+      setSseNotification(receivedNotification); // 전달받는 데이터는 NotificationResponse 형식. 예시- {notificationType:'DOOINGLE', cursor:5}
+      // TODO : 전달받는 데이터로 알림 컴포넌트 만들어서 알림 목록에 추가 (+ 팝업 띄우기 또는 알림 버튼 빨간색으로 바꾸기)
+      //  알림 컴포넌트 클릭 시 PersonalDooingle 페이지로 이동(cursor 함께 보내기)
+    });
+  }
 
   function handleMoreFeedButton(isEntireFeed) {
     const lastDooingleId = dooingles.slice(-1)[0]?.["dooingleId"]
@@ -100,6 +141,10 @@ export default function FeedPage() {
     setIsEntireFeed(false);
   }
 
+  function handleNewFeedNotificationButton() {
+    setNewFeedNotification(null);
+  }
+
   const handleConnect = () => {
 
     const sse = new EventSourcePolyfill(
@@ -128,7 +173,7 @@ export default function FeedPage() {
 
     sse.addEventListener('feed', e => {
       const receivedFeed = JSON.parse(e.data);
-      setFeed(receivedFeed);
+      setNewFeedNotification(receivedFeed);
       console.log(receivedFeed);
       // 전달받는 데이터는 DooingleResponse 형식
       // TODO : 전달받는 데이터로 뒹글 컴포넌트 만들어서 뒹글 목록 위에 추가
@@ -212,6 +257,12 @@ export default function FeedPage() {
               </button>
             </div>
           </div>
+
+          {newFeedNotification && (
+            <div className="border-2">
+              <button onClick={handleNewFeedNotificationButton}>새 피드가 있어요!</button>
+            </div>
+          )}
 
           <div className="py-[1rem]">
             {dooingles.map(dooingle => (

--- a/dooingle-front/src/pages/Feed.jsx
+++ b/dooingle-front/src/pages/Feed.jsx
@@ -24,12 +24,6 @@ const sliceInitialState = {
 }
  */
 
-const notificationInitialState = {
-  notificationType: null,
-  message: null,
-  cursor: 0
-}
-
 async function fetchDooinglesFeed(lastDooingleId = null) {
   const queryParameter = lastDooingleId === null ? "" : `?cursor=${lastDooingleId}`
 
@@ -57,8 +51,8 @@ async function fetchLoggedInUserLink() {
 
 export default function FeedPage() {
 
-  const [sseNotification, setSseNotification] = useState(notificationInitialState);
   const [newFeedNotification, setNewFeedNotification] = useState(null);
+  const [personalNotification, setPersonalNotification] = useState(null);
   const [currentUserLink, setCurrentUserLink] = useState(undefined);
   const [dooingles, setDooingles] = useState([]);
   const [isEntireFeed, setIsEntireFeed] = useState(true) // TODO isEntireFeed state가 정말 필요한지는 더 고민해볼 것
@@ -105,9 +99,9 @@ export default function FeedPage() {
         case "DOOINGLE": receivedNotification.message = "새 뒹글이 굴러왔어요!"; break;
         case "CATCH": receivedNotification.message = "내 뒹글에 캐치가 달렸어요!"; break;
       }
-      setSseNotification(receivedNotification); // 전달받는 데이터는 NotificationResponse 형식. 예시- {notificationType:'DOOINGLE', cursor:5}
+
       // TODO : 전달받는 데이터로 알림 컴포넌트 만들어서 알림 목록에 추가 (+ 팝업 띄우기 또는 알림 버튼 빨간색으로 바꾸기)
-      //  알림 컴포넌트 클릭 시 PersonalDooingle 페이지로 이동(cursor 함께 보내기)
+      setPersonalNotification(receivedNotification);
     });
   }
 
@@ -145,76 +139,8 @@ export default function FeedPage() {
     setNewFeedNotification(null);
   }
 
-  const handleConnect = () => {
-
-    const sse = new EventSourcePolyfill(
-        `${BACKEND_SERVER_ORIGIN}/api/notifications/connect`,
-        {withCredentials: true});
-
-    sse.addEventListener('connect', (e) => {
-      const { data: receivedConnectData } = e;
-
-      console.log('connect event data: ',receivedConnectData);
-    });
-
-    sse.addEventListener('notification', e => {
-      const receivedNotification = JSON.parse(e.data);
-
-      switch (receivedNotification.notificationType) {
-        case 'DOOINGLE': receivedNotification.message = "새 뒹글이 굴러왔어요!"; break;
-        case 'CATCH': receivedNotification.message = "내 뒹글에 캐치가 달렸어요!"; break;
-      }
-      setSseNotification(receivedNotification)
-
-      // 전달받는 데이터는 NotificationResponse 형식. 예시- {notificationType:'DOOINGLE', cursor:5}
-      // TODO : 전달받는 데이터로 알림 컴포넌트 만들어서 알림 목록에 추가 (+ 팝업 띄우기 또는 알림 버튼 빨간색으로 바꾸기)
-      //  알림 컴포넌트 클릭 시 PersonalDooingle 페이지로 이동(cursor 함께 보내기)
-    });
-
-    sse.addEventListener('feed', e => {
-      const receivedFeed = JSON.parse(e.data);
-      setNewFeedNotification(receivedFeed);
-      console.log(receivedFeed);
-      // 전달받는 데이터는 DooingleResponse 형식
-      // TODO : 전달받는 데이터로 뒹글 컴포넌트 만들어서 뒹글 목록 위에 추가
-    });
-  }
-
-  const [testData, setTestData] = useState(null);
-
-  const handleTestConnect = () => {
-
-    // SSE 연결 요청. EventSource 라는 인터페이스를 써야 하는데 헤더 전달을 지원하는 Event-Source-Polyfill 사용
-    const sse = new EventSourcePolyfill(`${BACKEND_SERVER_ORIGIN}/connect`);
-
-    // test-connect 라는 이름의 이벤트가 발생할 때 콘솔에 데이터 출력하는 이벤트 리스너 등록
-    sse.addEventListener('test-connect', (e) => {
-      // 첫 연결 시 만료 시간까지 아무런 데이터도 보내지 않으면 에러 발생하기 때문에 더미 데이터 보냄
-      const { data: receivedConnectData } = e;
-
-      console.log('connect event data: ',receivedConnectData);
-    });
-
-    // test 라는 이름의 이벤트가 발생할 때 콘솔에 변경된 데이터 출력하고, testData 업데이트하는 이벤트 리스너 등록
-    // 다른 브라우저에서 test 호출 시 내 브라우저에 서버에서 변경된 testData가 찍히게 됨
-    sse.addEventListener('test', e => {
-
-      const { data: receivedTestData } = e;
-
-      console.log("test event data", receivedTestData);
-      setTestData(receivedTestData);
-    });
-  }
-
-  // test 요청 버튼 클릭 시 localhost/test 로 요청 보냄
-  const handleTestClick = async () => {
-    await axios.post(`${BACKEND_SERVER_ORIGIN}/test`)
-        .then(function (response) {
-          console.log('handleTestClick',response);
-        })
-        .catch(function (error) {
-          console.log('error',error);
-        });
+  function handlePersonalNotificationButton() {
+    setPersonalNotification(null);
   }
 
   return (
@@ -226,17 +152,6 @@ export default function FeedPage() {
           <div className="flex flex-col items-center py-[3.75rem] gap-[1.25rem]">
             <ProfileImageFrame userLink={currentUserLink} />
             <Navigation/>
-            <div className="flex flex-col items-center pt-10">
-              <div className="text-xl text-red-500">알림 관련 임시</div>
-              <button onClick={handleConnect}>connect 요청</button>
-              <div className="py-[1rem]">
-                {sseNotification.message}
-                {sseNotification.cursor}
-              </div>
-              <button onClick={handleTestConnect}>test connect 요청</button>
-              <button onClick={handleTestClick}>test 요청</button>
-              <div>{testData}</div>
-            </div>
           </div>
         </nav>
 
@@ -263,14 +178,19 @@ export default function FeedPage() {
               <button onClick={handleNewFeedNotificationButton}>새 피드가 있어요!</button>
             </div>
           )}
+          {personalNotification && (
+            <div className="border-2">
+              <button onClick={handlePersonalNotificationButton}>새로 뒹글을 받았거나 내가 쓴 뒹글에 캐치가 있어요!</button>
+            </div>
+          )}
 
           <div className="py-[1rem]">
             {dooingles.map(dooingle => (
-                <Dooingle
-                    key={dooingle.dooingleId}
-                    ownerName={dooingle.ownerName}
-                    content={dooingle.content}
-                />
+              <Dooingle
+                key={dooingle.dooingleId}
+                ownerName={dooingle.ownerName}
+                content={dooingle.content}
+              />
             ))}
           </div>
           <button onClick={() => handleMoreFeedButton(isEntireFeed)} className="bg-amber-50">뒹글 더 보기</button>

--- a/src/main/kotlin/com/dooingle/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/dooingle/global/exception/GlobalExceptionHandler.kt
@@ -20,6 +20,7 @@ class GlobalExceptionHandler(
 
     @ExceptionHandler(Exception::class)
     fun handleAllException(e: Exception): ResponseEntity<ErrorResponse> {
+        logger.error(e.message, e)
         return handleException(CommonErrorCode.INTERNAL_SERVER_ERROR, e.message)
     }
 

--- a/src/main/kotlin/com/dooingle/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/dooingle/global/exception/GlobalExceptionHandler.kt
@@ -1,13 +1,22 @@
 package com.dooingle.global.exception
 
 import com.dooingle.global.exception.custom.RestApiException
+import com.dooingle.global.sse.SseEmitters
+import jakarta.servlet.http.HttpServletResponse
+import org.apache.catalina.connector.ClientAbortException
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 
 @RestControllerAdvice
-class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
+class GlobalExceptionHandler(
+    private val sseEmitters: SseEmitters
+) : ResponseEntityExceptionHandler() {
+    
+    private val logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java) // SSE 관련 에러를 회피하고 로그만 남기기 위해 두는 로거
 
     @ExceptionHandler(Exception::class)
     fun handleAllException(e: Exception): ResponseEntity<ErrorResponse> {
@@ -25,4 +34,22 @@ class GlobalExceptionHandler : ResponseEntityExceptionHandler() {
             .body(ErrorResponse(code = errorCode.name, message = message))
     }
 
+    @ExceptionHandler(ClientAbortException::class)
+    fun handleClientAbortException(exception: Exception, response: HttpServletResponse) {
+        sseEmitters.completeAllEmitters()
+        // spring sse exception handling로 구글링 중 https://amaran-th.github.io/Spring/[Spring]%20Server-Sent%20Events(SSE)/
+        // 여기서 힌트를 얻어서 이 에러가 발생하면 emitter 모두 끝내버림
+        // 리액트 엄격 모드 때문이 아니더라도 운영 환경에도 발생할 수 있는 에러라고 생각하여 처리할 필요가 있다고 생각했음
+
+        response.status = HttpStatus.UNAUTHORIZED.value()
+        response.contentType = "text/event-stream"
+        
+        // response.writer.write("event: error\ndata: ${exception.message}\n\n")
+        // TODO 이 부분은 나중에 다시 생각해봐야할 듯하다.
+        //  2024-03-27T16:53:04.602+09:00  WARN 34744 --- [nio-8080-exec-3] .m.m.a.ExceptionHandlerExceptionResolver : Failure in @ExceptionHandler com.dooingle.global.exception.GlobalExceptionHandler#handleClientAbortException(Exception, HttpServletResponse)
+        //  java.lang.IllegalStateException: getOutputStream() has already been called for this response
+        //  결국 위 에러는 해결하진 않고 로그만 찍고 회피함
+        logger.error(exception.message, exception)
+        response.flushBuffer()
+    }
 }

--- a/src/main/kotlin/com/dooingle/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/dooingle/global/security/SecurityConfig.kt
@@ -1,6 +1,7 @@
 package com.dooingle.global.security
 
 import com.dooingle.global.jwt.JwtAuthenticationFilter
+import jakarta.servlet.DispatcherType
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -34,13 +35,23 @@ class SecurityConfig(
             .cors { it.configurationSource(corsConfigurationSource()) }
             .headers { it.frameOptions { frameOptionsConfig -> frameOptionsConfig.sameOrigin() } }
             .authorizeHttpRequests {
-                it.requestMatchers(
-                    "/api/**",
-                ).authenticated()
+                // (1) dispatcher type이 async인 경우 모두 허용 - CoyoteAdapter asyncDispatch access denied로 검색하여 https://github.com/spring-projects/spring-security/issues/11962 참고 후 임시 조치해둔 것
+                // requestMatchers("/api/notification").permitAll()으로 할 수도 있었겠지만 이 쪽이 더 낫다고 판단함
+                // cf. dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()가  requestMatchers("/api/**").authenticated()보다 뒤에 있는 경우에는 적용이 안 됨
+                it.dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
+                    // (2) 요청 url /api/** 패턴은 모두 인증 필요
                     .requestMatchers(
-                        "/oauth2/login/**", "/oauth2/callback/**", "/swagger-ui/**", "/v3/api-docs/**", "/h2-console/**",
-                ).permitAll() // 로그인, 콜백 리다이렉트 url은 인증 불필요
-            // TODO: "/swagger-ui/**", "/v3/api-docs/**", "/h2-console/**"는 개발 환경에서만 인증 불필요하게 만들기
+                        "/api/**",
+                    ).authenticated()
+                    // (3) 요청 url 아래 패턴은 모두 허용(로그인, 인증 서버 콜백 리다이렉트 url 등)
+                    // TODO: "/swagger-ui/**", "/v3/api-docs/**", "/h2-console/**"는 개발 환경에서만 인증 불필요하게 만들기
+                    .requestMatchers(
+                        "/oauth2/login/**",
+                        "/oauth2/callback/**",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/h2-console/**",
+                    ).permitAll()
             }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .exceptionHandling {

--- a/src/main/kotlin/com/dooingle/global/sse/SseEmitters.kt
+++ b/src/main/kotlin/com/dooingle/global/sse/SseEmitters.kt
@@ -19,7 +19,7 @@ class SseEmitters {
 
     // ConcurrentHashMap 에 저장
     fun addWith(userId: Long): SseEmitter {
-        val emitter = SseEmitter() // 만료 시간 설정 (기본 30초). 만료 시간 되면 브라우저에서 자동으로 서버에 재연결 요청
+        val emitter = SseEmitter(5 * 1_000) // 만료 시간 설정 (기본 30초). 만료 시간 되면 브라우저에서 자동으로 서버에 재연결 요청
         // emitter 생성 후 만료 시간까지 아무 데이터도 보내지 않으면 브라우저에서 재연결 요청시 503 Service Unavailable 에러 발생하므로
         // 처음 연결 시 더미 데이터 전달
         emitter.sendData(eventName = "connect", data = CONNECTED_MESSAGE)

--- a/src/main/kotlin/com/dooingle/global/sse/SseEmitters.kt
+++ b/src/main/kotlin/com/dooingle/global/sse/SseEmitters.kt
@@ -19,7 +19,7 @@ class SseEmitters {
 
     // ConcurrentHashMap 에 저장
     fun addWith(userId: Long): SseEmitter {
-        val emitter = SseEmitter(5 * 1_000) // 만료 시간 설정 (기본 30초). 만료 시간 되면 브라우저에서 자동으로 서버에 재연결 요청
+        val emitter = SseEmitter(60 * 1_000) // 만료 시간 설정 (기본 30초). 만료 시간 되면 브라우저에서 자동으로 서버에 재연결 요청
         // emitter 생성 후 만료 시간까지 아무 데이터도 보내지 않으면 브라우저에서 재연결 요청시 503 Service Unavailable 에러 발생하므로
         // 처음 연결 시 더미 데이터 전달
         emitter.sendData(eventName = "connect", data = CONNECTED_MESSAGE)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,6 +12,7 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+    open-in-view: false
 
 management:
   endpoints:

--- a/src/main/resources/application-local-dev-infra.yml
+++ b/src/main/resources/application-local-dev-infra.yml
@@ -13,6 +13,7 @@ spring:
         highlight_sql: true
         use_sql_comments: true
 #        dialect: org.hibernate.dialect.MySQLDialect # dialect 설정 hibernate에 명시적으로 주면 에러 발생함
+    open-in-view: false
   h2:
     console:
       enabled: true

--- a/src/main/resources/application-local-h2.yml
+++ b/src/main/resources/application-local-h2.yml
@@ -13,6 +13,7 @@ spring:
         highlight_sql: true
         use_sql_comments: true
 #        dialect: org.hibernate.dialect.MySQLDialect # dialect 설정 hibernate에 명시적으로 주면 에러 발생함
+    open-in-view: false
   h2:
     console:
       enabled: true

--- a/src/main/resources/application-local-h2.yml
+++ b/src/main/resources/application-local-h2.yml
@@ -27,7 +27,7 @@ logging:
   level:
     'org.hibernate.SQL': debug
     'org.hibernate.orm.jdbc.bind': trace
-    #'org.springframework.security.web.FilterChainProxy': debug
+    'org.springframework.securitweb': debug
 
 dooingler:
   list:

--- a/src/main/resources/application-local-memory-h2.yml
+++ b/src/main/resources/application-local-memory-h2.yml
@@ -13,6 +13,7 @@ spring:
         highlight_sql: true
         use_sql_comments: true
 #        dialect: org.hibernate.dialect.MySQLDialect # dialect 설정 hibernate에 명시적으로 주면 에러 발생함
+    open-in-view: false
   h2:
     console:
       enabled: true


### PR DESCRIPTION
## 연관 이슈
- closes #106 
- (참고) dev가 아닌 frontend/dev로의 PR입니다.

## 해당 작업을 한 동기/이유는 무엇인가요?
- 뒹글 피드 페이지에서 뒹글에 대한 알림을 받아 사용자의 서비스 참여 유도
- 뒹글 피드 페이지에서 뒹글의 답변 유무 표시 및 해당 글로 이동을 지원하여 서비스 참여 유도

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] 뒹글 피드 페이지에서 새 뒹글 알림 기능 UI 표현
  - 기존 새 뒹글 알림 기능 코드 정리
  - 알림에 따라 UI 표시되도록 함
- [x] 뒹글 피드 페이지 답변이 있는 뒹글을 표시
- [x] 뒹글 받은 사람 이름, 답변 표시 등을 누르면 관련 위치로 이동하도록 함

### 백엔드 수정 사항
- SSE 예외 처리 로직 및 global error handler 관련 수정
- OSIV 설정 수정