### PR TITLE
refactor: 팔로우 컨트롤러, 개인 뒹글 페이지 캐치 리스폰스 관련 리팩토링

### DIFF
--- a/src/main/kotlin/com/dooingle/domain/catchdomain/dto/CatchResponse.kt
+++ b/src/main/kotlin/com/dooingle/domain/catchdomain/dto/CatchResponse.kt
@@ -6,7 +6,7 @@ import java.time.ZonedDateTime
 data class CatchResponse(
     val catchId: Long,
     val content: String?,
-    val createdAt: ZonedDateTime,
+    val createdAt: ZonedDateTime?, // TODO non-nullable로 할 경우 com.querydsl.core.types.ExpressionException: null 예외 발생함
     val deletedAt: ZonedDateTime? = null,
 ){
     companion object {

--- a/src/main/kotlin/com/dooingle/domain/catchdomain/dto/CatchResponse.kt
+++ b/src/main/kotlin/com/dooingle/domain/catchdomain/dto/CatchResponse.kt
@@ -4,16 +4,17 @@ import com.dooingle.domain.catchdomain.model.Catch
 import java.time.ZonedDateTime
 
 data class CatchResponse(
-    val catchId: Long?,
+    val catchId: Long,
     val content: String?,
-    val createdAt: ZonedDateTime?
+    val createdAt: ZonedDateTime,
+    val deletedAt: ZonedDateTime? = null,
 ){
     companion object {
         fun from(catch: Catch): CatchResponse {
             return CatchResponse(
                 catchId = catch.id!!,
                 content = catch.content,
-                createdAt = catch.createdAt
+                createdAt = catch.createdAt,
             )
         }
     }

--- a/src/main/kotlin/com/dooingle/domain/dooingle/repository/DooingleQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/repository/DooingleQueryDslRepositoryImpl.kt
@@ -117,7 +117,8 @@ class DooingleQueryDslRepositoryImpl(
                         CatchResponse::class.java,
                         catch.id,
                         catch.content,
-                        catch.createdAt
+                        catch.createdAt,
+                        catch.deletedAt,
                     ),
                     dooingle.createdAt
                 )

--- a/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
+++ b/src/main/kotlin/com/dooingle/domain/dooingle/service/DooingleService.kt
@@ -65,7 +65,20 @@ class DooingleService(
             ?: throw SocialUserNotFoundByUserLinkException(userLink = ownerUserLink)
         val pageRequest = PageRequest.ofSize(USER_FEED_PAGE_SIZE)
 
-        return dooingleRepository.getPersonalPageBySlice(owner, cursor, pageRequest)
+        val personalPageBySlice = dooingleRepository.getPersonalPageBySlice(owner, cursor, pageRequest)
+
+        return personalPageBySlice.map { getResponseWithCatchContentHided(it) }
+    }
+
+    private fun getResponseWithCatchContentHided(dooingleAndCatchResponse: DooingleAndCatchResponse): DooingleAndCatchResponse{
+        return if (dooingleAndCatchResponse.catch?.deletedAt == null) {
+            // catch가 null이거나 catch의 deletedAt이 null인 경우 map 빠른 종료
+            dooingleAndCatchResponse
+        } else {
+            // deletedAt이 null이 아닌 경우에 대해서 CatchResponse의 content를 숨기는 로직 진행
+            val contentHidedCatch = dooingleAndCatchResponse.catch.copy(content = null)
+            dooingleAndCatchResponse.copy(catch = contentHidedCatch)
+        }
     }
 
     fun getDooingleFeed(cursor: Long?, pageRequest: PageRequest): Slice<DooingleFeedResponse> {

--- a/src/main/kotlin/com/dooingle/domain/follow/controller/FollowController.kt
+++ b/src/main/kotlin/com/dooingle/domain/follow/controller/FollowController.kt
@@ -49,7 +49,7 @@ class FollowController(
     @Operation(summary = "내 팔로워 수 조회")
     @GetMapping("/{toUserLink}/number")
     fun showFollowersNumber(
-        @RequestParam toUserLink: String
+        @PathVariable toUserLink: String
     ) : ResponseEntity<Int>{
         return ResponseEntity
             .status(HttpStatus.OK)

--- a/src/test/kotlin/com/dooingle/domain/catchdomain/service/CatchServiceDBTest.kt
+++ b/src/test/kotlin/com/dooingle/domain/catchdomain/service/CatchServiceDBTest.kt
@@ -59,7 +59,7 @@ class CatchServiceDBTest @Autowired constructor(
         val dooingle = dooingle
         val addCatchRequest = AddCatchRequest("캐치 테스트")
 
-        every { mockNotificationService.addCatchNotification(any(), any()) } just runs
+        every { mockNotificationService.addCatchNotification(any(), any(), any()) } just runs
 
         // when
         catchService.addCatch(dooingle.id!!, owner.id!!, addCatchRequest)
@@ -94,7 +94,7 @@ class CatchServiceDBTest @Autowired constructor(
         val dooingle = dooingle
         val addCatchRequest = AddCatchRequest("캐치 테스트")
 
-        every { mockNotificationService.addCatchNotification(any(), any()) } just runs
+        every { mockNotificationService.addCatchNotification(any(), any(), any()) } just runs
 
         // when
         val catchResponse = catchService.addCatch(dooingle.id!!, owner.id!!, addCatchRequest)


### PR DESCRIPTION
## 연관 이슈
- closes #168

## 해당 작업을 한 동기/이유는 무엇인가요?
- 프론트엔드 수정 중 API 수정 필요사항에 대한 리팩토링입니다.

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] 팔로우 컨트롤러 중 팔로워 수 반환 메서드 파라미터 변경
  - @ RequestParam이 아니라 @ PathVariable 사용
- [x] 뒹글 서비스 중 캐치 리스폰스가 deletedAt이 null이 아닌 경우 content를 보이지 않게 하여 반환
  - 캐치 리스폰스에 deletedAt 정보 포함
  - deletedAt이 null이 아닐 경우 content를 null로 변경해서 반환
  - cf. CatchResponse의 createdAt 프로퍼티를 non-nullable로 둘 경우 QueryDSL 에러가 발생하여 nullable로 둬서 에러 발생하지 않게 , 정확한 이유는 파악하지 못했음