### PR TITLE
fix: notification response 관련 버그 수정

### DIFF
--- a/src/main/kotlin/com/dooingle/domain/catchdomain/service/CatchService.kt
+++ b/src/main/kotlin/com/dooingle/domain/catchdomain/service/CatchService.kt
@@ -40,7 +40,7 @@ class CatchService(
         dooingle.catch = catch
         catchRepository.save(catch)
 
-        notificationService.addCatchNotification(user = dooingle.guest, dooingleId = dooingleId, ownerUserLink = dooingle.owner.userLink)
+        notificationService.addCatchNotification(user = dooingle.guest, dooingleId = dooingleId)
 
         return CatchResponse.from(catch)
     }

--- a/src/main/kotlin/com/dooingle/domain/notification/dto/NotificationResponse.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/dto/NotificationResponse.kt
@@ -1,17 +1,7 @@
 package com.dooingle.domain.notification.dto
 
-import com.dooingle.domain.notification.model.Notification
-
 data class NotificationResponse(
     val notificationType: String,
     val cursor: Long,
     val ownerUserLink: String
-) {
-    companion object {
-        fun from(notification: Notification) = NotificationResponse(
-            notificationType = notification.notificationType.toString(),
-            cursor = notification.resourceId + 1,
-            ownerUserLink = notification.ownerUserLink
-        )
-    }
-}
+)

--- a/src/main/kotlin/com/dooingle/domain/notification/dto/NotificationSseResponse.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/dto/NotificationSseResponse.kt
@@ -1,0 +1,15 @@
+package com.dooingle.domain.notification.dto
+
+import com.dooingle.domain.notification.model.Notification
+
+data class NotificationSseResponse(
+    val notificationType: String,
+    val cursor: Long,
+) {
+    companion object {
+        fun from(notification: Notification) = NotificationSseResponse(
+            notificationType = notification.notificationType.toString(),
+            cursor = notification.resourceId + 1,
+        )
+    }
+}

--- a/src/main/kotlin/com/dooingle/domain/notification/model/Notification.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/model/Notification.kt
@@ -16,9 +16,6 @@ class Notification(
 
     @Column
     val resourceId: Long,
-
-    @Column
-    val ownerUserLink: String
 ) {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long? = null

--- a/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/com/dooingle/domain/notification/repository/NotificationQueryDslRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.dooingle.domain.notification.repository
 
+import com.dooingle.domain.dooingle.model.QDooingle
 import com.dooingle.domain.notification.dto.NotificationResponse
 import com.dooingle.domain.notification.model.QNotification
 import com.dooingle.domain.user.model.QSocialUser
@@ -17,7 +18,9 @@ class NotificationQueryDslRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : NotificationQueryDslRepository{
     private val notification = QNotification.notification
+    private val dooingle = QDooingle.dooingle
     private val user = QSocialUser.socialUser
+    private val owner = QSocialUser("ow")
 
     override fun getNotificationBySlice(
         user: SocialUser,
@@ -46,10 +49,13 @@ class NotificationQueryDslRepositoryImpl(
                 Projections.constructor(
                     NotificationResponse::class.java,
                     notification.notificationType.stringValue(),
-                    notification.resourceId
+                    notification.resourceId,
+                    owner.userLink,
                 )
             ).from(notification)
             .join(notification.user, user)
+            .join(dooingle).on(dooingle.id.eq(notification.resourceId))
+            .join(owner).on(owner.eq(dooingle.owner))
             .where(whereClause)
             .orderBy(notification.id.desc())
             .limit(selectSize)

--- a/src/test/kotlin/com/dooingle/domain/catchdomain/service/CatchServiceDBTest.kt
+++ b/src/test/kotlin/com/dooingle/domain/catchdomain/service/CatchServiceDBTest.kt
@@ -59,7 +59,7 @@ class CatchServiceDBTest @Autowired constructor(
         val dooingle = dooingle
         val addCatchRequest = AddCatchRequest("캐치 테스트")
 
-        every { mockNotificationService.addCatchNotification(any(), any(), any()) } just runs
+        every { mockNotificationService.addCatchNotification(any(), any()) } just runs
 
         // when
         catchService.addCatch(dooingle.id!!, owner.id!!, addCatchRequest)
@@ -94,7 +94,7 @@ class CatchServiceDBTest @Autowired constructor(
         val dooingle = dooingle
         val addCatchRequest = AddCatchRequest("캐치 테스트")
 
-        every { mockNotificationService.addCatchNotification(any(), any(), any()) } just runs
+        every { mockNotificationService.addCatchNotification(any(), any()) } just runs
 
         // when
         val catchResponse = catchService.addCatch(dooingle.id!!, owner.id!!, addCatchRequest)

--- a/src/test/kotlin/com/dooingle/domain/notification/service/NotificationSseTest.kt
+++ b/src/test/kotlin/com/dooingle/domain/notification/service/NotificationSseTest.kt
@@ -5,6 +5,7 @@ import com.dooingle.domain.dooingle.model.Dooingle
 import com.dooingle.domain.dooingle.repository.DooingleRepository
 import com.dooingle.domain.dooinglecount.repository.DooingleCountRepository
 import com.dooingle.domain.notification.dto.NotificationResponse
+import com.dooingle.domain.notification.dto.NotificationSseResponse
 import com.dooingle.domain.notification.model.NotificationType
 import com.dooingle.domain.notification.repository.NotificationRepository
 import com.dooingle.domain.user.model.SocialUser
@@ -106,10 +107,9 @@ class NotificationSseTest(
         val dooingle = dooingleRepository.findByIdOrNull(dooingleId)
 
         val notificationString = objectMapper.writeValueAsString(
-            NotificationResponse(
+            NotificationSseResponse(
                 notificationType = NotificationType.DOOINGLE.toString(),
                 cursor = dooingle!!.id!! + 1,
-                ownerUserLink = dooingle.owner.userLink
             )
         )
         eventWrapper.receivedData[1] shouldBe notificationString // 유저 알림
@@ -149,10 +149,9 @@ class NotificationSseTest(
         val catch = catchRepository.findByIdOrNull(catchId)
 
         val notificationString = objectMapper.writeValueAsString(
-            NotificationResponse(
+            NotificationSseResponse(
                 notificationType = NotificationType.CATCH.toString(),
                 cursor = catch!!.dooingle.id!! + 1,
-                ownerUserLink = catch!!.dooingle.owner.userLink
             )
         )
         eventWrapperOfA.receivedData[1] shouldBe notificationString
@@ -201,10 +200,9 @@ class NotificationSseTest(
         val dooingle = dooingleRepository.findByIdOrNull(dooingleId)
 
         val notificationString = objectMapper.writeValueAsString(
-            NotificationResponse(
+            NotificationSseResponse(
                 notificationType = NotificationType.DOOINGLE.toString(),
                 cursor = dooingle!!.id!! + 1,
-                ownerUserLink = dooingle.owner.userLink
             )
         )
         eventWrapperOfA1.receivedData[1] shouldBe notificationString // 유저 알림


### PR DESCRIPTION
## 연관 이슈
- closes #173 

## 해당 작업을 한 동기/이유는 무엇인가요?
- notification response 관련 런타임 에러로 인해 알림 기능 확인 불가

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- Notification 엔티티에서 ownerUserLink 프로퍼티 제거
- NotificationResponse 관련 QueryDSL 메서드의 NotificationResponse 생성자에 ownerUserLink 추가
  - 조인이 여러 번 발생하여 우려되는 지점 있으나, 일단 진행함
- NotificationResponse와 NotificationSseResponse 분리
- 그 밖에 NotificationSseResponse를 사용하는 곳에서 ownerUserLink 제거