### PR TITLE
refactor: authentication 없이 특정 화면 확인 및 API 호출 가능하도록 함

### DIFF
--- a/dooingle-front/src/App.jsx
+++ b/dooingle-front/src/App.jsx
@@ -13,10 +13,31 @@ import AuthProvider from "./contexts/AuthContext.jsx";
 import LogoutPage from "./pages/Logout.jsx";
 import NotificationProvider from "./contexts/NotificationContext.jsx";
 import ReportProvider from "./contexts/ReportContext.jsx";
+import LoginPage from "./pages/Login.jsx";
 
 const router = createBrowserRouter([
-  { path: '/', element: <WelcomePage /> },
-  { path: '/admin', element: <AdminHomePage /> },
+  { path: '/', element: (
+    <AuthProvider>
+      <WelcomePage />
+    </AuthProvider>
+    )
+  },
+  {
+    path: '/login',
+    element: (
+      <AuthProvider>
+        <LoginPage />
+      </AuthProvider>
+    ),
+  },
+  {
+    path: '/logout',
+    element: (
+      <AuthProvider>
+        <LogoutPage />
+      </AuthProvider>
+    ),
+  },
   {
     element: (
       <AuthProvider>
@@ -41,14 +62,7 @@ const router = createBrowserRouter([
       }
     ]
   },
-  {
-    path: '/logout',
-    element: (
-      <AuthProvider>
-        <LogoutPage />
-      </AuthProvider>
-    ),
-  },
+  { path: '/admin', element: <AdminHomePage /> },
 ])
 
 export default function App() {

--- a/dooingle-front/src/components/Header.jsx
+++ b/dooingle-front/src/components/Header.jsx
@@ -1,15 +1,17 @@
 import {Link} from "react-router-dom";
 import {useEffect, useRef, useState} from "react";
-import {useNotification} from "../hooks/useContext.js";
+import {useAuth, useNotification} from "../hooks/useContext.js";
 import {fetchNotifications} from "../fetch.js";
 
 export default function Header() {
+  const {isAuthenticated} = useAuth();
   const [showUserMenu, setShowUserMenu] = useState(false);
   const [showNotificationDropdown, setShowNotificationDropdown] = useState(false);
   const [notifications, setNotifications] = useState([])
   const userMenuRef = useRef();
   const notificationDropdownRef = useRef();
   const {personalNotification, setPersonalNotification} = useNotification();
+  const {setShowLoginInductionModal} = useAuth();
 
   useEffect(() => {
     function handleOutsideClick(event) {
@@ -55,6 +57,10 @@ export default function Header() {
     setShowNotificationDropdown(!showNotificationDropdown)
   }
 
+  function handleLoginButton() {
+    setShowLoginInductionModal(true);
+  }
+
   return (
     <header className="shadow-[inset_0_-0.0625rem_0_0_#d3d3d3]">
       <div className="grid grid-cols-12 gap-x-[2.5rem] mx-[8.75rem] h-[4.5rem] ml-40px">
@@ -72,7 +78,7 @@ export default function Header() {
             <img src="/notice.svg" alt="공지사항 링크" className="h-[2.5rem]"/>
           </Link>
 
-          <div ref={notificationDropdownRef} className="relative -z-1">
+          {isAuthenticated && <div ref={notificationDropdownRef} className="relative -z-1">
             <button onClick={toggleNotificationDropdown} className="focus:outlink-none">
               {!personalNotification && <img src="/notification-off.svg" alt="알림 드롭다운" className="h-[2.5rem]"/>}
               {personalNotification && <img src="/notification-on.svg" alt="알림 드롭다운" className="h-[2.5rem]"/>}
@@ -88,7 +94,8 @@ export default function Header() {
                         {(notification.notificationType === "DOOINGLE") && "새 뒹글이 굴러왔어요!"}
                         {(notification.notificationType === "CATCH") && "뒹글에 캐치가 달렸어요!"}
                       </span>
-                      <Link to={`/personal-dooingles/${notification.ownerUserLink}`} className="self-center text-[0.75rem] hover:text-[#ef7ec2]"> 보러 가기</Link>
+                      <Link to={`/personal-dooingles/${notification.ownerUserLink}`}
+                            className="self-center text-[0.75rem] hover:text-[#ef7ec2]"> 보러 가기</Link>
                     </div>
                   </li>
                 )}
@@ -101,13 +108,13 @@ export default function Header() {
                 }
               </ul>
             )}
-          </div>
+          </div>}
 
           <div ref={userMenuRef} className="relative -z-1">
             <button onClick={toggleUserMenu} className="focus:outlink-none">
               <img src="/user-menu.svg" alt="사용자 메뉴 드롭다운 메뉴" className="h-[2.5rem]"/>
             </button>
-            {showUserMenu && (
+            {showUserMenu && isAuthenticated && (
               <ul className="absolute flex flex-col gap-[0.125rem] right-0 w-[8rem]
               bg-white rounded-b-[0.5rem] border-[#d3d3d3] border-[0.03125rem] border-t-0 shadow-sm pb-[0.25rem]">
                 <li className="px-[1.25rem] py-[0.375rem] hover:bg-[#eaecf9]">
@@ -115,6 +122,14 @@ export default function Header() {
                 </li>
                 <li className="px-[1.25rem] py-[0.375rem] hover:bg-[#eaecf9]">
                   <Link to={"/logout"}>로그아웃</Link>
+                </li>
+              </ul>
+            )}
+            {showUserMenu && !isAuthenticated && (
+              <ul className="absolute flex flex-col gap-[0.125rem] right-0 w-[8rem]
+              bg-white rounded-b-[0.5rem] border-[#d3d3d3] border-[0.03125rem] border-t-0 shadow-sm pb-[0.25rem]">
+                <li className="px-[1.25rem] py-[0.375rem] hover:bg-[#eaecf9]">
+                  <button onClick={handleLoginButton}>로그인</button>
                 </li>
               </ul>
             )}

--- a/dooingle-front/src/components/modal/LoginInductionModal.jsx
+++ b/dooingle-front/src/components/modal/LoginInductionModal.jsx
@@ -1,38 +1,44 @@
 import {BACKEND_SERVER_ORIGIN, FRONTEND_SERVER_ORIGIN} from "../../env.js";
 import {useAuth} from "../../hooks/useContext.js";
+import {useNavigate} from "react-router-dom";
 
 export default function LoginInductionModal() {
-  const {showLoginInductionModal, setShowLoginInductionModal} = useAuth();
+  const {isAuthenticated, showLoginInductionModal, setShowLoginInductionModal} = useAuth();
+  const navigate = useNavigate();
 
   const handleStartButton = () => {
     window.location.href = `${BACKEND_SERVER_ORIGIN}/oauth2/login/kakao`
   }
 
-  const handleToWelcomePageButton = () => {
-    setShowLoginInductionModal(false)
-    window.location.href = `${FRONTEND_SERVER_ORIGIN}/`
+  const handleToPreviousPageButton = () => {
+    setShowLoginInductionModal(false);
+    navigate(-1);
   }
 
   return (
     <>
       {
-        // TODO ChatGPT 코드 - 스타일은 세부 조정 필요
         showLoginInductionModal &&
         <div className="fixed flex items-center inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50" id="my-modal">
           <div className="relative -inset-y-[4rem] mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
             <div className="mt-3 text-center">
-              <h3 className="text-lg leading-6 font-medium text-gray-900">뒹글을 로그인한지 오래 지났네요!</h3>
-              <div className="mt-2 px-7 py-3">
-                <p className="text-sm text-gray-500">다시 로그인해주세요!</p>
-              </div>
+              {isAuthenticated && <>
+                <h3 className="text-lg leading-6 font-medium text-gray-900">뒹글을 로그인한지 오래 지났네요!</h3>
+                <div className="mt-2 px-7 py-3">
+                  <p className="text-sm text-gray-500">다시 로그인해주세요!</p>
+                </div>
+              </>}
+              {!isAuthenticated && <>
+                <h3 className="text-lg leading-6 font-medium text-gray-900">뒹글에 로그인해볼까요?</h3>
+              </>}
               <div className="flex flex-col items-center justify-center box-border gap-[0.625rem] h-[5.625rem]">
                 <button onClick={handleStartButton}
                         className="lg:w-[80%] md:w-[60%] sm:w-[40%] w-[20%] flex justify-center">
                   <img src="/kakao_login_large_narrow.png" alt="카카오 소셜 로그인 버튼" className="max-w-[80%]"/>
                 </button>
               </div>
-              <button onClick={handleToWelcomePageButton} className="items-center">
-                <p className="text-sm text-gray-500 text-center">첫 페이지로 돌아가기</p>
+              <button onClick={handleToPreviousPageButton} className="items-center">
+                <p className="text-sm text-gray-500 text-center">이전 페이지로 돌아가기</p>
               </button>
             </div>
           </div>

--- a/dooingle-front/src/contexts/NotificationContext.jsx
+++ b/dooingle-front/src/contexts/NotificationContext.jsx
@@ -1,20 +1,24 @@
 import {createContext, useEffect, useState} from "react";
 import {EventSourcePolyfill} from "event-source-polyfill";
 import {BACKEND_SERVER_ORIGIN} from "../env.js";
+import {useAuth} from "../hooks/useContext.js";
 
 export const NotificationContext = createContext()
 
 export default function NotificationProvider({children}) {
 
+  const {isAuthenticated} = useAuth();
   const [newFeedNotification, setNewFeedNotification] = useState(null);
   const [personalNotification, setPersonalNotification] = useState(null);
 
   useEffect(() => {
+    if (!isAuthenticated) return; // isAuthenticated가 false이면 SSE 요청을 하지 못하도록 함
+
     const eventSource = new EventSourcePolyfill(`${BACKEND_SERVER_ORIGIN}/api/notifications/connect`,
       {withCredentials: true}
     );
 
-    addSseConnectionEventListenerToEventSource(eventSource)
+    addSseConnectionEventListenerToEventSource(eventSource);
     addNewFeedNotificationEventListenerToEventSource(eventSource);
     addPersonalNotificationEventListenerToEventSource(eventSource);
 

--- a/dooingle-front/src/fetch.js
+++ b/dooingle-front/src/fetch.js
@@ -206,3 +206,16 @@ export async function fetchAddBadReport(reportedTargetType, reportedTargetId, re
   );
   return response.data;
 }
+
+export async function fetchLogout() {
+  await axios.post(
+    `${BACKEND_SERVER_ORIGIN}/logout`,
+    null,
+    {
+      withCredentials: true,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    },
+  );
+}

--- a/dooingle-front/src/layouts/MainLayout.jsx
+++ b/dooingle-front/src/layouts/MainLayout.jsx
@@ -6,14 +6,16 @@ import {useAuth} from "../hooks/useContext.js";
 
 export default function MainLayout() {
 
-  const {authenticatedUserLink} = useAuth();
+  const {isAuthenticated, authenticatedUserLink} = useAuth();
 
   return (
     <div className="grid grid-cols-12 gap-x-[2.5rem] mx-[8.75rem] h-[4.5rem] ml-40px">
       <nav className="col-start-1 col-span-3 flex justify-center text-[#5f6368]">
         <div className="flex flex-col items-center py-[3.75rem] gap-[1.25rem]">
-          <ProfileImageFrame userLink={authenticatedUserLink}/>
-          <Navigation/>
+          {isAuthenticated && <>
+            <ProfileImageFrame userLink={authenticatedUserLink}/>
+            <Navigation/>
+          </>}
         </div>
       </nav>
 

--- a/dooingle-front/src/pages/Feed.jsx
+++ b/dooingle-front/src/pages/Feed.jsx
@@ -2,14 +2,15 @@ import Dooingle from "../components/Dooingle.jsx";
 import {useEffect, useRef, useState} from "react";
 import MorePostButton from "../components/button/MorePostButton.jsx";
 import {fetchDooinglesFeedSlice, fetchDooinglesFeedSliceOfFollowing} from "../fetch.js"
-import {useNotification} from "../hooks/useContext.js";
+import {useAuth, useNotification} from "../hooks/useContext.js";
 
 export default function FeedPage() {
 
   const [dooingles, setDooingles] = useState([]);
   const [showingEntireFeed, setShowingEntireFeed] = useState(true) // TODO isEntireFeed state가 정말 필요한지는 더 고민해볼 것
   const hasNextSlice = useRef(false);
-  const {newFeedNotification, setNewFeedNotification} = useNotification()
+  const {isAuthenticated} = useAuth();
+  const {newFeedNotification, setNewFeedNotification} = useNotification();
   const {personalNotification, setPersonalNotification} = useNotification();
 
   useEffect(() => {
@@ -92,14 +93,14 @@ export default function FeedPage() {
             </div>
           </button>
         </div>
-        <div
+        {isAuthenticated && <div
           className={"px-[0.5rem] " + (showingEntireFeed ? "hover:shadow-[inset_0_-0.125rem_0_0_#fa61bd]" : "shadow-[inset_0_-0.125rem_0_0_#fa61bd]")}>
           <button onClick={handleFollowingFeedButton} className="py-[0.5rem]">
             <div className={"" + (showingEntireFeed ? "hover:text-[#fa61bd]" : "text-[#fa61bd]")}>
               팔로우
             </div>
           </button>
-        </div>
+        </div>}
       </div>
 
       {newFeedNotification && (
@@ -107,7 +108,7 @@ export default function FeedPage() {
                 className="fixed top-[3.8rem] self-center max-w-fit mt-[0.75rem] mr-[0.5rem] px-[0.5rem] py-[0.25rem]
                   rounded-[0.625rem] text-[0.75rem] text-white font-bold bg-[#fa61bd]
                   border-[0.0625rem] border-[#fa61bd] animate-pulse">
-          새 피드가 있어요!
+        새 피드가 있어요!
         </button>
       )}
       {personalNotification && (

--- a/dooingle-front/src/pages/Login.jsx
+++ b/dooingle-front/src/pages/Login.jsx
@@ -3,20 +3,20 @@ import Spinner from "../components/miscellaneous/Spinner.jsx";
 import {useAuth} from "../hooks/useContext.js";
 import {useNavigate} from "react-router-dom";
 
-export default function LogoutPage() {
+export default function LoginPage() {
   
-  const {logout} = useAuth()
+  const {login} = useAuth()
   const navigate = useNavigate();
 
   useEffect(() => {
-    logout();
-    navigate("/", {replace: true});
-  }, [logout]);
+    login();
+    navigate("/feeds")
+  }, [login]);
 
   return (
     <div className="w-full h-screen flex flex-col justify-center items-center">
       <Spinner/>
-      <p className="mt-[2rem] text-[1.5rem] font-semibold">로그아웃 처리 중...</p>
+      <p className="mt-[2rem] text-[1.5rem] font-semibold">로그인 처리 중...</p>
     </div>
   );
 }

--- a/dooingle-front/src/pages/MyProfile.jsx
+++ b/dooingle-front/src/pages/MyProfile.jsx
@@ -1,6 +1,7 @@
 import {useEffect, useRef, useState} from "react";
 import SmallSubmitButton from "../components/button/SmallSubmitButton.jsx";
 import {fetchCurrentProfile, fetchUpdateProfile} from "../fetch.js";
+import {useAuth} from "../hooks/useContext.js";
 
 const profileInitialState = {
   nickname: "",
@@ -13,11 +14,14 @@ export default function MyProfilePage() {
   const [updateImageUrlPreview, setUpdateImageUrlPreview] = useState("");
   const imageFileInputRef = useRef();
   const descriptionInputRef = useRef();
+  const {isAuthenticated, setShowLoginInductionModal} = useAuth();
 
   useEffect(() => {
-    fetchCurrentProfile().then(fetchedProfile => {
+    isAuthenticated && fetchCurrentProfile().then(fetchedProfile => {
       setPrevProfile(fetchedProfile)
     })
+
+    !isAuthenticated && setShowLoginInductionModal(true)
   }, []);
 
   function handleImageInput(event) {

--- a/dooingle-front/src/pages/PersonalDooingle.jsx
+++ b/dooingle-front/src/pages/PersonalDooingle.jsx
@@ -21,7 +21,7 @@ import DeleteModal from "../components/modal/DeleteModal.jsx";
 
 export default function PersonalDooinglePage() {
 
-  const {authenticatedUserLink} = useAuth()
+  const {isAuthenticated, authenticatedUserLink} = useAuth()
   const [dooinglesAndCatches, setDooinglesAndCatches] = useState([]);
   const [pageOwnerUserProfile, setPageOwnerUserProfile] = useState({});
   const [isFollowingUser, setIsFollowingUser] = useState(false);
@@ -53,7 +53,7 @@ export default function PersonalDooinglePage() {
   }, [pageOwnerUserLink, searchParams]);
   
   useEffect(() => {
-    fetchIsFollowingUser(pageOwnerUserLink).then(result => {
+    isAuthenticated && fetchIsFollowingUser(pageOwnerUserLink).then(result => {
       setIsFollowingUser(result)
     })
 
@@ -140,8 +140,9 @@ export default function PersonalDooinglePage() {
               <div className="flex items-center gap-[0.75rem]">
                 <span className="text-[1.5rem] font-bold text-white">{pageOwnerUserProfile.nickname}</span>
                 <div className="flex gap-[0.5rem] items-center">
-                  {(isCurrentUserEqualToPageOwner || isFollowingUser) && <button onClick={handleCancelFollowButton} className="text-[1.5rem] font-extrabold text-[#8692ff]">★</button>}
-                  {(!isCurrentUserEqualToPageOwner && !isFollowingUser) && <button onClick={handleAddFollowButton} className="text-[1.5rem] font-extrabold text-[#FFFFFF] hover:text-[#8692ff] transition-colors">☆</button>}
+                  {!isAuthenticated && <div className="text-[1.5rem] font-extrabold text-[#8692ff]">★</div>}
+                  {isAuthenticated && (isCurrentUserEqualToPageOwner || isFollowingUser) && <button onClick={handleCancelFollowButton} className="text-[1.5rem] font-extrabold text-[#8692ff]">★</button>}
+                  {isAuthenticated && (!isCurrentUserEqualToPageOwner && !isFollowingUser) && <button onClick={handleAddFollowButton} className="text-[1.5rem] font-extrabold text-[#FFFFFF] hover:text-[#8692ff] transition-colors">☆</button>}
                   <span className="mt-[0.125rem] text-[1.125rem] text-white">{followerCount}</span>
                 </div>
               </div>
@@ -159,11 +160,11 @@ export default function PersonalDooinglePage() {
         {/* Feed와 배치 다른 부분: nav의 py가 3.75rem -> 3rem, 본문 섹션 py가 2.75rem -> 0.75rem */}
 
         {/* nav */}
-        <nav className="col-start-1 col-span-3 flex justify-center text-[#5f6368]">
+        {isAuthenticated && <nav className="col-start-1 col-span-3 flex justify-center text-[#5f6368]">
           <div className="flex flex-col items-center py-[3rem] gap-[1.25rem]">
-            <Navigation />
+            <Navigation/>
           </div>
-        </nav>
+        </nav>}
 
         {/* 뒹글 & 캐치 */}
         <section className="col-start-4 col-span-6 flex flex-col py-[0.75rem] text-[#5f6368]">

--- a/dooingle-front/src/pages/Welcome.jsx
+++ b/dooingle-front/src/pages/Welcome.jsx
@@ -1,4 +1,5 @@
 import {BACKEND_SERVER_ORIGIN} from "../env.js";
+import {Link} from "react-router-dom";
 
 export default function WelcomePage() {
 
@@ -18,6 +19,7 @@ export default function WelcomePage() {
           <img src="/kakao_login_large_narrow.png" alt="카카오 소셜 로그인 버튼" className="lg:w-[60%] md:w-[30%] sm:w-[30%] w-[20%] "/>
         </button>
       </div>
+      <Link to="/feeds">그냥 구경할래요</Link>
     </section>
   )
 }

--- a/src/main/kotlin/com/dooingle/domain/follow/controller/FollowController.kt
+++ b/src/main/kotlin/com/dooingle/domain/follow/controller/FollowController.kt
@@ -7,6 +7,7 @@ import com.dooingle.global.security.UserPrincipal
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
@@ -26,7 +27,9 @@ class FollowController(
             .body(followService.follow(toUserLink, userPrincipal.id))
     }
 
+    @Operation(summary = "팔로우하는 사용자인지 여부 조회")
     @GetMapping("/{toUserLink}")
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     fun isFollowingUser(
         @AuthenticationPrincipal userPrincipal: UserPrincipal,
         @PathVariable toUserLink: String,
@@ -38,6 +41,7 @@ class FollowController(
 
     @Operation(summary = "내 팔로우 목록 조회")
     @GetMapping
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     fun showFollowingList(
         @AuthenticationPrincipal userPrincipal: UserPrincipal
     ) : ResponseEntity<List<FollowDetailResponse>> {
@@ -46,7 +50,7 @@ class FollowController(
             .body(followService.showFollowingList(userPrincipal.id))
     }
 
-    @Operation(summary = "내 팔로워 수 조회")
+    @Operation(summary = "팔로워 수 조회")
     @GetMapping("/{toUserLink}/number")
     fun showFollowersNumber(
         @PathVariable toUserLink: String

--- a/src/main/kotlin/com/dooingle/domain/user/controller/LogoutController.kt
+++ b/src/main/kotlin/com/dooingle/domain/user/controller/LogoutController.kt
@@ -1,33 +1,28 @@
 package com.dooingle.domain.user.controller
 
-import com.dooingle.global.oauth2.provider.OAuth2Provider
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
-import java.net.URI
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class LogoutController(@Value("\${frontend.domain}") frontendUri: String) {
-
-    private val frontendWelcomePageUri = frontendUri
+class LogoutController {
 
     @PostMapping("/logout")
-    fun redirectLoginPage(response: HttpServletResponse): ResponseEntity<Unit> {
+    fun logout(response: HttpServletResponse): ResponseEntity<Unit> {
         val accessTokenInCookie = ResponseCookie
             .from("accessToken")
             .httpOnly(true) /* .secure(true) // https 사용할 경우 빌더에 추가 */
             .path("/")
-            .maxAge(0)
+            .maxAge(0) // accessToken 쿠키 만료시킴
             .build()
 
         val headers = HttpHeaders()
-            .also { it.location = URI.create(frontendWelcomePageUri) } // 헤더에 리다이렉트 URI 설정
             .also { it.add(HttpHeaders.SET_COOKIE, accessTokenInCookie.toString()) } // 헤더에 SET COOKIE 헤더 추가, 내용은 위에서 만들어놓은 accessTokenInCookie 객체
 
-        return ResponseEntity(headers, HttpStatus.PERMANENT_REDIRECT)
+        return ResponseEntity(headers, HttpStatus.OK)
     }
 }

--- a/src/main/kotlin/com/dooingle/domain/user/controller/OAuth2LoginController.kt
+++ b/src/main/kotlin/com/dooingle/domain/user/controller/OAuth2LoginController.kt
@@ -19,7 +19,7 @@ class OAuth2LoginController(
     private val oAuth2LoginService: OAuth2LoginService,
     @Value("\${frontend.domain}") frontendUri: String,
 ) {
-    private val frontendFeedPageUri = "$frontendUri/feeds"
+    private val frontendLoginPageUri = "$frontendUri/login"
 
     @GetMapping("/login/{provider}")
     fun redirectLoginPage(@PathVariable provider: OAuth2Provider, response: HttpServletResponse) {
@@ -44,7 +44,7 @@ class OAuth2LoginController(
             .build()
 
         val headers = HttpHeaders()
-            .also { it.location = URI.create(frontendFeedPageUri) } // 헤더에 리다이렉트 URI 설정
+            .also { it.location = URI.create(frontendLoginPageUri) } // 헤더에 리다이렉트 URI 설정
             .also { it.add(HttpHeaders.SET_COOKIE, accessTokenInCookie.toString()) } // 헤더에 SET COOKIE 헤더 추가, 내용은 위에서 만들어놓은 accessTokenInCookie 객체
 
         return ResponseEntity(headers, HttpStatus.PERMANENT_REDIRECT)

--- a/src/main/kotlin/com/dooingle/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/com/dooingle/domain/user/controller/UserController.kt
@@ -7,6 +7,7 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
@@ -43,6 +44,7 @@ class UserController(
     }
 
     @GetMapping("/profile")
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     fun getProfile(@AuthenticationPrincipal userPrincipal: UserPrincipal) : ResponseEntity<ProfileResponse>{
         return ResponseEntity.status(HttpStatus.OK).body(socialUserService.getProfile(userPrincipal.id))
     }
@@ -59,6 +61,7 @@ class UserController(
     }
 
     @GetMapping("/current-dooingler")
+    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     fun getCurrentDooingler(@AuthenticationPrincipal userPrincipal: UserPrincipal) : ResponseEntity<DooinglerResponse>{
         return ResponseEntity.status(HttpStatus.OK).body(socialUserService.getCurrentDooingler(userPrincipal.id))
     }

--- a/src/main/kotlin/com/dooingle/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/dooingle/global/security/SecurityConfig.kt
@@ -35,10 +35,21 @@ class SecurityConfig(
     @Profile("prod")
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        return commonHttpSecurity(http).authorizeHttpRequests {
+            // (prod 환경) 요청 url 아래 패턴은 ADMIN만 허용(swagger 문서)
+            it.requestMatchers(
+                "/swagger-ui/**",
+                "/v3/api-docs/**",
+            ).hasAnyRole("ADMIN")
+        }.build()
+    }
+
+    private fun commonHttpSecurity(http: HttpSecurity): HttpSecurity {
         return http
             .securityMatcher(NegatedRequestMatcher(EndpointRequest.toAnyEndpoint()))
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
+            .logout { it.disable() } // /login?logout으로 리다이렉션 동작 등 비활성화
             .csrf { it.disable() }
             .cors { it.configurationSource(corsConfigurationSource()) }
             .headers { it.frameOptions { frameOptionsConfig -> frameOptionsConfig.sameOrigin() } }
@@ -47,28 +58,27 @@ class SecurityConfig(
                 // requestMatchers("/api/notification").permitAll()으로 할 수도 있었겠지만 이 쪽이 더 낫다고 판단함
                 // cf. dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()가  requestMatchers("/api/**").authenticated()보다 뒤에 있는 경우에는 적용이 안 됨
                 it.dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
-                    // (2) 요청 url /api/** 패턴은 모두 인증 필요
+                    // (2) GET 메서드 요청 /api/** 패턴은 모두 허용
+                    .requestMatchers(
+                        HttpMethod.GET,
+                        "/api/**",
+                    ).permitAll()
+                    // (3) GET 메서드 요청 외의 /api/** 패턴은 모두 인증 필요
                     .requestMatchers(
                         "/api/**",
                     ).authenticated()
-                    // (3) 요청 url 아래 패턴은 모두 허용(로그인, 인증 서버 콜백 리다이렉트 url 등)
+                    // (4) 로그인, 로그아웃 관련 패턴은 모두 허용
                     .requestMatchers(
                         "/oauth2/login/**",
                         "/oauth2/callback/**",
+                        "/logout",
                     ).permitAll()
-                    // (4) 요청 url 아래 패턴은 ADMIN만 허용
-                    .requestMatchers(
-                        "/swagger-ui/**",
-                        "/v3/api-docs/**",
-                        "/h2-console/**",
-                    ).hasAnyRole("ADMIN") // hasRole() 사용할 경우 에러 - collection이 아닐 때만 가능한 듯
             }
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
             .exceptionHandling {
                 it.authenticationEntryPoint(authenticationEntrypoint)
                 it.accessDeniedHandler(accessDeniedHandler)
             }
-            .build()
     }
 
     private fun corsConfigurationSource(): CorsConfigurationSource {
@@ -94,44 +104,15 @@ class SecurityConfig(
 
     @Profile("!prod")
     @Bean
-    fun filterChainForLocal(http: HttpSecurity): SecurityFilterChain {
-        return http
-            .securityMatcher(NegatedRequestMatcher(EndpointRequest.toAnyEndpoint()))
-            .httpBasic { it.disable() }
-            .formLogin { it.disable() }
-            .logout { it.disable() } // /login?logout으로 리다이렉션 동작 등 비활성화
-            .csrf { it.disable() }
-            .cors { it.configurationSource(corsConfigurationSource()) }
-            .headers { it.frameOptions { frameOptionsConfig -> frameOptionsConfig.sameOrigin() } }
+    fun filterChainNotForProduction(http: HttpSecurity): SecurityFilterChain {
+        return commonHttpSecurity(http)
             .authorizeHttpRequests {
-                // (1) dispatcher type이 async인 경우 모두 허용 - CoyoteAdapter asyncDispatch access denied로 검색하여 https://github.com/spring-projects/spring-security/issues/11962 참고 후 임시 조치해둔 것
-                // requestMatchers("/api/notification").permitAll()으로 할 수도 있었겠지만 이 쪽이 더 낫다고 판단함
-                // cf. dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()가  requestMatchers("/api/**").authenticated()보다 뒤에 있는 경우에는 적용이 안 됨
-                it.dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
-                    // (2) GET 메서드 요청 /api/** 패턴은 모두 허용
-                    .requestMatchers(
-                        HttpMethod.GET,
-                        "/api/**",
-                    ).permitAll()
-                    // (3) GET 메서드 요청 외의 /api/** 패턴은 모두 인증 필요
-                    .requestMatchers(
-                        "/api/**",
-                    ).authenticated()
-                    // (4) 요청 url 아래 패턴은 모두 허용(로그인, 인증 서버 콜백 리다이렉트 url 등)
-                    .requestMatchers(
-                        "/logout",
-                        "/oauth2/login/**",
-                        "/oauth2/callback/**",
-                        "/swagger-ui/**",
-                        "/v3/api-docs/**",
-                        "/h2-console/**",
-                    ).permitAll()
-            }
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter::class.java)
-            .exceptionHandling {
-                it.authenticationEntryPoint(authenticationEntrypoint)
-                it.accessDeniedHandler(accessDeniedHandler)
-            }
-            .build()
+                // (prod 환경이 아닌 경우) 요청 url 아래 패턴은 모두 허용(swagger 문서, H2 콘솔 등)
+                it.requestMatchers(
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**",
+                    "/h2-console/**",
+                ).permitAll()
+            }.build()
     }
 }

--- a/src/main/kotlin/com/dooingle/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/dooingle/global/security/SecurityConfig.kt
@@ -99,6 +99,7 @@ class SecurityConfig(
             .securityMatcher(NegatedRequestMatcher(EndpointRequest.toAnyEndpoint()))
             .httpBasic { it.disable() }
             .formLogin { it.disable() }
+            .logout { it.disable() } // /login?logout으로 리다이렉션 동작 등 비활성화
             .csrf { it.disable() }
             .cors { it.configurationSource(corsConfigurationSource()) }
             .headers { it.frameOptions { frameOptionsConfig -> frameOptionsConfig.sameOrigin() } }
@@ -118,6 +119,7 @@ class SecurityConfig(
                     ).authenticated()
                     // (4) 요청 url 아래 패턴은 모두 허용(로그인, 인증 서버 콜백 리다이렉트 url 등)
                     .requestMatchers(
+                        "/logout",
                         "/oauth2/login/**",
                         "/oauth2/callback/**",
                         "/swagger-ui/**",


### PR DESCRIPTION
## 연관 이슈
- closes #189 

## 해당 작업을 한 동기/이유는 무엇인가요?
- 사용자가 회원가입, 로그인 하지 않고 기본적인 서비스를 구경할 수 있도록
  - authentication 없이 특정 화면을 확인하고 일부 GET 메서드 요청 가능하도록 수정했습니다.

## 리뷰어에게 작업 또는 변경 내용을 상세히 설명해주세요
- [x] SecurityConfig 수정
  - 스프링 시큐리티 기본 로그아웃 동작 비활성화
  - prod 환경 필터체인과 !prod 환경 필터체인에서 공통 부분 추출
  - "api/**" 패턴 GET 메서드 요청 엔드포인트 모두 노출
    - FollowController와 UserController의 일부 API는 인가를 이용하여 호출 막음
    - GET 메서드 외의 POST, PUT, DELETE, PATCH 요청은 기존 그대로 authentication 필요

- [x] 프론트엔드 수정
  - 웰컴 페이지에서 구경할 수 있도록 하는 버튼 추가
  - 인증되지 않은 사용자는 SSE 요청하지 않도록 함
  - 로그인, 로그아웃 시 isAuthenticated 상태를 브라우저 로컬 스토리지에 저장하여 유지
  - 로그인하지 않은 사용자에게 일부 화면 및 버튼 숨김
    - Header, MainLayout, Feed, PersonalDooingle 등 컴포넌트에서 일부 버튼 숨김 및 authentication 필요 메서드 호출하지 않음
    - MyProfile 화면 접근하지 못하도록 함